### PR TITLE
Add cli option to prevent direct vcs push.

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -94,6 +94,15 @@ After running the script you should manually do the following steps:
 4. Check in possible changes in the zopefoundation/meta repository.
 
 
+CLI arguments
++++++++++++++
+
+The following arguments are supported.
+
+--no-push
+  Avoid pushing at the end of the configuration run.
+
+
 Hints
 -----
 

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -25,6 +25,11 @@ parser = argparse.ArgumentParser(
     description='Use configuration for a package.')
 parser.add_argument(
     'path', type=str, help='path to the repository to be configured')
+parser.add_argument(
+    '--no-push',
+    dest='no_push',
+    action='store_true',
+    help='Prevent direct push.')
 parser.add_argument('type', choices=['pure-python',
                                      'pure-python-without-pypy'],
                     help='type of the config to be used, see README.rst')
@@ -78,7 +83,8 @@ try:
          'setup.cfg', 'tox.ini', '.gitignore', '.travis.yml', 'MANIFEST.in',
          '.editorconfig')
     call('git', 'ci', '-m', f'Configuring for {config_type}')
-    call('git', 'push', '--set-upstream', 'origin', branch_name)
+    if not args.no_push:
+        call('git', 'push', '--set-upstream', 'origin', branch_name)
     print()
     print('If everything went fine up to here:')
     if updating:


### PR DESCRIPTION
This help during development, debugging and in case of non-trivial changes. 