### PR TITLE
Fix differences between the two configurations

### DIFF
--- a/config/pure-python-without-pypy/MANIFEST.in
+++ b/config/pure-python-without-pypy/MANIFEST.in
@@ -7,6 +7,11 @@ include tox.ini
 
 exclude MANIFEST.in
 
+recursive-include docs *.bat
+recursive-include docs *.py
+recursive-include docs *.rst
+recursive-include docs Makefile
+
 recursive-include src *.pt
 recursive-include src *.rst
 recursive-include src *.txt

--- a/config/pure-python-without-pypy/gitignore
+++ b/config/pure-python-without-pypy/gitignore
@@ -5,6 +5,7 @@
 *.pyc
 *.pyo
 .coverage
+.coverage.*
 .installed.cfg
 .mr.developer.cfg
 .tox/
@@ -14,6 +15,7 @@ build/
 coverage.xml
 develop-eggs/
 dist/
+docs/_build
 eggs/
 htmlcov/
 lib/

--- a/config/pure-python/gitignore
+++ b/config/pure-python/gitignore
@@ -5,6 +5,7 @@
 *.pyc
 *.pyo
 .coverage
+.coverage.*
 .installed.cfg
 .mr.developer.cfg
 .tox/

--- a/config/pure-python/setup.cfg
+++ b/config/pure-python/setup.cfg
@@ -8,5 +8,6 @@ doctests = 1
 
 [check-manifest]
 ignore =
-    .travis.yml
     .editorconfig
+    .meta.cfg
+    .travis.yml

--- a/config/pure-python/tox.ini
+++ b/config/pure-python/tox.ini
@@ -41,7 +41,7 @@ deps =
 commands =
     coverage run -m zope.testrunner --test-path=src []
     coverage html
-    coverage report -m
+    coverage report -m {coverage_report_options}
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
I don't see why "without-pypy" implies it won't have Sphinx
documentation, or why the "with-pypy" config is not capable of enforcing
coverage thresholds.  Or why .meta.cfg files should not be ignored by
check-manifest in "with-pypy" configs.

These seem like accidental differences introduced by changing one or the
other config while forgetting the other one exists.

I also snuck in a .gitignore for .coverage.*, because people (and
projects) sometimes use coverage in parallel mode.