### PR TITLE
Add support for packages using multi processes in tests like buildout recipes.

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -19,6 +19,12 @@ packages:
 
   - Configuration for a pure python package which supports PyPy.
 
+* pure-python-with-multiprocess
+
+  - Configuration for a pure python package which supports PyPy and is tested
+    using multiple processes, so coverage has to be configured in a special
+    way. (Used for e. g. buildout recipes.)
+
 * pure-python-without-pypy
 
   - Configuration for a pure python package which does not supports PyPy,

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -28,13 +28,15 @@ def call(*args, capture_output=False):
     return result
 
 
-def copy_with_meta(source, destination, config_type):
+def copy_with_meta(source, destination, config_type, **kw):
     """Copy the source file to destination and a hint of origin."""
     with open(source) as f_:
         f_data = f_.read()
 
     with open(destination, 'w') as f_:
         f_.write(META_HINT.format(config_type=config_type))
+        if kw:
+            f_data = f_data.format(**kw)
         f_.write(f_data)
 
 
@@ -48,6 +50,7 @@ parser.add_argument(
     action='store_true',
     help='Prevent direct push.')
 parser.add_argument('type', choices=['pure-python',
+                                     'pure-python-with-multiprocess',
                                      'pure-python-without-pypy'],
                     help='type of the config to be used, see README.rst')
 
@@ -96,6 +99,16 @@ copy_with_meta(
 shutil.copy(config_type_path / 'tox.ini', path)
 shutil.copy(config_type_path / 'travis.yml', path / '.travis.yml')
 
+add_coveragerc = False
+rm_coveragerc = False
+if (config_type_path / 'coveragerc').exists():
+    copy_with_meta(
+        config_type_path / 'coveragerc', path / '.coveragerc', config_type,
+        package_name=path.name)
+    add_coveragerc = True
+elif (path / '.coveragerc').exists():
+    rm_coveragerc = True
+
 
 # Modify templates with meta options.
 tox_ini_path = path / 'tox.ini'
@@ -113,8 +126,6 @@ cwd = os.getcwd()
 branch_name = f'config-with-{config_type}'
 try:
     os.chdir(path)
-    if pathlib.Path('.coveragerc').exists():
-        call('git', 'rm', '.coveragerc')
     if pathlib.Path('bootstrap.py').exists():
         call('git', 'rm', 'bootstrap.py')
     call(pathlib.Path(cwd) / 'bin' / 'tox', '-p', 'auto')
@@ -139,6 +150,10 @@ try:
     call('git', 'add',
          'setup.cfg', 'tox.ini', '.gitignore', '.travis.yml', 'MANIFEST.in',
          '.editorconfig', '.meta.cfg')
+    if rm_coveragerc:
+        call('git', 'rm', '.coveragerc')
+    if add_coveragerc:
+        call('git', 'add', '.coveragerc')
     call('git', 'commit', '-m', f'Configuring for {config_type}')
     if not args.no_push:
         call('git', 'push', '--set-upstream', 'origin', branch_name)

--- a/config/default/MANIFEST.in
+++ b/config/default/MANIFEST.in
@@ -2,8 +2,7 @@ include *.rst
 include *.txt
 include buildout.cfg
 include tox.ini
-
-exclude MANIFEST.in
+include .coveragerc
 
 recursive-include docs *.bat
 recursive-include docs *.py

--- a/config/default/setup.cfg
+++ b/config/default/setup.cfg
@@ -3,6 +3,8 @@ universal = 1
 
 [flake8]
 doctests = 1
+# provided to doctests by buildoutSetUp()
+builtins = write, system, cat, join
 
 [check-manifest]
 ignore =

--- a/config/pure-python-with-multiprocess/coveragerc
+++ b/config/pure-python-with-multiprocess/coveragerc
@@ -1,0 +1,11 @@
+[run]
+source = {package_name}
+plugins = coverage_python_version
+branch = true
+parallel = true
+
+[paths]
+source =
+    src/
+    .tox/*/lib/python*/site-packages/
+    .tox/pypy*/site-packages/

--- a/config/pure-python-with-multiprocess/packages.txt
+++ b/config/pure-python-with-multiprocess/packages.txt
@@ -1,10 +1,4 @@
 # Packages configured for the pure python version are listed here.
 # Do not edit the file by hand but use the script config-package.py as
 # described in README.rst
-zope.authentication
-z3c.wizard
-zope.browsermenu
-zope.app.publication
-zope.app.broken
-zope.app.appsetup
-zope.browser
+z3c.recipe.tag

--- a/config/pure-python-with-multiprocess/tox.ini
+++ b/config/pure-python-with-multiprocess/tox.ini
@@ -1,0 +1,61 @@
+# Generated from:
+# https://github.com/zopefoundation/meta/tree/master/config/pure-python-with-multiprocess
+[tox]
+envlist =
+    lint,
+    py27,
+    pypy,
+    py35,
+    py36,
+    py37,
+    py38,
+    pypy3,
+    coverage
+
+[testenv]
+usedevelop = true
+deps =
+    zope.testrunner
+commands =
+    zope-testrunner --test-path=src []
+extras = test
+
+[testenv:lint]
+basepython = python3
+skip_install = true
+deps =
+    flake8
+    check-manifest
+    check-python-versions
+commands =
+    flake8 src setup.py
+    check-manifest
+    check-python-versions
+
+[testenv:coverage]
+basepython = python3
+setenv =
+    COVERAGE_PROCESS_START={{toxinidir}}/.coveragerc
+deps =
+    coverage
+    coverage-python-version
+    zope.testrunner
+commands =
+    coverage erase
+    coverage run -m zope.testrunner --test-path=src []
+    coverage combine
+    coverage html
+    coverage report -m {coverage_report_options}
+
+[coverage:report]
+precision = 2
+exclude_lines =
+    pragma: nocover
+    except ImportError:
+    raise NotImplementedError
+    if __name__ == '__main__':
+    self.fail
+    raise AssertionError
+
+[coverage:html]
+directory = htmlcov

--- a/config/pure-python-with-multiprocess/travis.yml
+++ b/config/pure-python-with-multiprocess/travis.yml
@@ -1,0 +1,34 @@
+# Generated from:
+# https://github.com/zopefoundation/meta/tree/master/config/pure-python-with-multiprocess
+language: python
+python:
+  - 2.7
+  - pypy
+  - 3.5
+  - 3.6
+  - 3.7
+  - 3.8
+  - pypy3
+
+matrix:
+  include:
+    - name: "lint"
+      python: 3.7
+      env: TOXENV="lint"
+    - name: "coverage"
+      python: 3.7
+      env: TOXENV="coverage"
+      after_success:
+        - coveralls
+
+install:
+  - pip install -U pip
+  - pip install -U tox-travis coveralls
+
+script:
+  - tox
+
+notifications:
+  email: false
+
+cache: pip


### PR DESCRIPTION
See zopefoundation/z3c.recipe.tag#8 which was created using this template.

zc.buildout expects an explicit `.coveragerc` so we cannot put the coverage configuration into `tox.ini`.