### PR TITLE
Ignore .eggs/

### DIFF
--- a/config/default/gitignore
+++ b/config/default/gitignore
@@ -6,6 +6,7 @@
 .coverage.*
 .installed.cfg
 .mr.developer.cfg
+.eggs/
 .tox/
 __pycache__/
 bin/


### PR DESCRIPTION
This directory shows up when setuptools has to download some packages itself, usually because of setup_requires.

Because I currently have a log of junk show up in ~/src/zopefoundation/zope.app.publication/.eggs/, and I see that its .gitignore says

```
# Generated from:
# https://github.com/zopefoundation/meta/tree/master/config/pure-python
```