### PR TITLE
Add ability to install additional packages on GHA.

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -198,6 +198,11 @@ updated. Example:
         "src/foo/bar.mo",
         ]
 
+    [github-actions]
+    additional-install = [
+        "sudo apt-get install libxml2-dev libxslt-dev"
+    ]
+
 Meta Options
 ````````````
 
@@ -271,6 +276,15 @@ additional-ignores
 
 ignore-bad-ideas
   Ignore bad idea files/directories matching these patterns.
+
+
+GitHub Actions options
+``````````````````````
+
+additional-install
+  Additional lines to be executed during the install dependencies step when
+  running the tests on GitHub Actions. This option has to be a list of strings.
+
 
 Hints
 -----

--- a/config/README.rst
+++ b/config/README.rst
@@ -200,7 +200,7 @@ updated. Example:
 
     [github-actions]
     additional-install = [
-        "sudo apt-get install libxml2-dev libxslt-dev"
+        "sudo apt-get update && sudo apt-get install -y libxml2-dev libxslt-dev"
     ]
 
 Meta Options

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -180,6 +180,8 @@ elif (path / '.coveragerc').exists():
 
 coverage_run_additional_config = meta_cfg['coverage-run'].get(
     'additional-config', [])
+gha_additional_install = meta_cfg['github-actions'].get(
+    'additional-install', [])
 fail_under = meta_cfg['coverage'].setdefault('fail-under', 0)
 copy_with_meta(
     'tox.ini.j2', path / 'tox.ini', config_type,
@@ -190,7 +192,7 @@ copy_with_meta(
 copy_with_meta(
     'tests.yml.j2', workflows / 'tests.yml', config_type,
     with_pypy=with_pypy, with_legacy_python=with_legacy_python,
-    with_docs=with_docs)
+    with_docs=with_docs, gha_additional_install=gha_additional_install)
 
 
 # Modify MANIFEST.in with meta options

--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -53,6 +53,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install tox
+{% for line in gha_additional_install %}
+        %(line)s
+{% endfor %}
     - name: Test
       run: tox -e ${{ matrix.config[1] }}
     - name: Coverage

--- a/config/pure-python/packages.txt
+++ b/config/pure-python/packages.txt
@@ -49,3 +49,7 @@ z3c.testing
 z3c.traverser
 zope.testing
 zope.schema
+zc.intid
+zc.queue
+zope.apidoc
+zope.app.authentication

--- a/config/pure-python/packages.txt
+++ b/config/pure-python/packages.txt
@@ -41,3 +41,9 @@ z3c.csvvocabulary
 z3c.evalexception
 zope.sendmail
 zope.publisher
+z3c.formwidget.ckeditor
+z3c.layer.ready2go
+z3c.menu.ready2go
+z3c.sampledata
+z3c.testing
+z3c.traverser


### PR DESCRIPTION
This is needed for https://github.com/zopefoundation/z3c.layer.ready2go/pull/1
where lxml cloud not be installed on PyPy3 without liblxml and libxslt
dev packages installed.