### PR TITLE
pip install wheel in Appveyor builds

### DIFF
--- a/config/default/appveyor.yml.j2
+++ b/config/default/appveyor.yml.j2
@@ -27,7 +27,7 @@ install:
   - ps: if (-not (Test-Path $env:PYTHON)) { throw "No $env:PYTHON" }
   - echo "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 > "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\bin\amd64\vcvars64.bat"
   - python -m pip install -U pip
-  - pip install -U setuptools
+  - pip install -U setuptools wheel
   - pip install -U -e .[test]
 
 build: false


### PR DESCRIPTION
This appears to be necessary for at least zope.sendmail on Python 3.9,
where (due to lack of binary Windows wheels of zope.proxy for 3.9) pip
install fails to build and install zope.proxy from sources if wheel is
not available.

(I think this is due to a new pip version?  Because older pips used to
fall back to setup.py install if setup.py bdist_wheel failed.)