### PR TITLE
Add support for Zope Product packages.

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -172,7 +172,6 @@ updated. Example:
 
     [coverage]
     fail-under = 98
-    tox-ini-command = "coverage run {envbindir}/test_with_gs []"
 
     [coverage-run]
     additional-config = [
@@ -192,6 +191,7 @@ updated. Example:
         "setenv =",
         "    ZOPE_INTERFACE_STRICT_IRO=1",
         ]
+    coverage-command = "coverage run {envbindir}/test_with_gs []"
 
     [flake8]
     additional-config = [
@@ -264,12 +264,6 @@ The corresponding section is named: ``[coverage]``.
 fail-under
   A minimal value of code coverage below which a test failure is issued.
 
-tox-ini-command
-  This option replaces the coverage call in the section ``[testenv:coverage]``
-  in ``tox.ini``. *Caution:* only the actual call to collect the coverage data
-  is replaced the reporting calls are not changed. This option has to be a
-  string. If it is not set or empty the default is used.
-
 
 Coverage:run options
 ````````````````````
@@ -296,6 +290,13 @@ testenv-commands
 testenv-additional
   Additional lines for the section ``[testenv]`` in ``tox.ini``.
   This option has to be a list of strings.
+
+coverage-command
+  This option replaces the coverage call in the section ``[testenv:coverage]``
+  in ``tox.ini``. *Caution:* only the actual call to collect the coverage data
+  is replaced. The calls to create the reporting are not changed. This option
+  has to be a string. If it is not set or empty the default is used.
+
 
 Flake8 options
 ``````````````

--- a/config/README.rst
+++ b/config/README.rst
@@ -23,7 +23,13 @@ packages:
 
 * pure-python
 
-  - Configuration for a pure python package which supports PyPy.
+  - Configuration for a pure python package.
+
+* zope-product
+
+  - Configuration for a pure python package which uses zc.buildout inside
+    ``tox.ini`` to be able to pin the installed dependency versions the same
+    way ``buildout.cfg`` does it.
 
 
 Contents
@@ -166,6 +172,7 @@ updated. Example:
 
     [coverage]
     fail-under = 98
+    tox-ini-command = "coverage run {envbindir}/test_with_gs []"
 
     [coverage-run]
     additional-config = [
@@ -174,6 +181,13 @@ updated. Example:
         ]
 
     [tox]
+    testenv-commands-pre = [
+        "{envbindir}/buildout -c ...",
+    ]
+    testenv-commands = [
+        "{envbindir}/test {posargs:-cv}",
+        "{envbindir}/test_with_gs {posargs:-cv}",
+    ]
     testenv-additional = [
         "setenv =",
         "    ZOPE_INTERFACE_STRICT_IRO=1",
@@ -202,6 +216,9 @@ updated. Example:
     ignore-bad-ideas = [
         "src/foo/bar.mo",
         ]
+
+    [isort]
+    known_first_party = "Products.GenericSetup Products.CMFCore"
 
     [github-actions]
     additional-install = [
@@ -247,6 +264,12 @@ The corresponding section is named: ``[coverage]``.
 fail-under
   A minimal value of code coverage below which a test failure is issued.
 
+tox-ini-command
+  This option replaces the coverage call in the section ``[testenv:coverage]``
+  in ``tox.ini``. *Caution:* only the actual call to collect the coverage data
+  is replaced the reporting calls are not changed. This option has to be a
+  string. If it is not set or empty the default is used.
+
 
 Coverage:run options
 ````````````````````
@@ -261,6 +284,14 @@ tox.ini options
 ```````````````
 
 The corresponding section is named: ``[tox]``.
+
+testenv-commands-pre
+  Replacement for the default ``commands_pre`` option in ``[testenv]`` of
+  ``tox.ini``. This option has to be a list of strings without indentation.
+
+testenv-commands
+  Replacement for the default ``commands`` option in ``[testenv]`` of
+  ``tox.ini``. This option has to be a list of strings without indentation.
 
 testenv-additional
   Additional lines for the section ``[testenv]`` in ``tox.ini``.
@@ -299,6 +330,19 @@ additional-ignores
 
 ignore-bad-ideas
   Ignore bad idea files/directories matching these patterns.
+
+Isort options
+`````````````
+
+The corresponding section is named: ``[isort]``.
+
+known_first_party
+  This options defines the value for ``known_first_party`` in the ``isort``
+  configuration. Please note the usage of underscores for the option name,
+  which used to be consistent with the name of the option in ``isort``.
+  This option has to be a single string. It defaults to the empty string.
+  (Currently only the configuration type ``zope-product`` supports ``isort``
+  configurations.)
 
 
 GitHub Actions options

--- a/config/README.rst
+++ b/config/README.rst
@@ -218,7 +218,7 @@ updated. Example:
         ]
 
     [isort]
-    known_first_party = "Products.GenericSetup Products.CMFCore"
+    known_first_party = "Products.GenericSetup, Products.CMFCore"
 
     [github-actions]
     additional-install = [

--- a/config/buildout-recipe/coveragerc.j2
+++ b/config/buildout-recipe/coveragerc.j2
@@ -23,4 +23,4 @@ exclude_lines =
     self.fail\(
 
 [html]
-directory = htmlcov
+directory = parts/htmlcov

--- a/config/buildout-recipe/tox.ini.j2
+++ b/config/buildout-recipe/tox.ini.j2
@@ -14,7 +14,11 @@ deps =
     zope.testrunner
 commands =
     coverage erase
+{% if coverage_command %}
+    %(coverage_command)s
+{% else %}
     coverage run -m zope.testrunner --test-path=src []
+{% endif %}
 {% if with_sphinx_doctests %}
     coverage run -a -m sphinx -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
 {% endif %}

--- a/config/buildout-recipe/tox.ini.j2
+++ b/config/buildout-recipe/tox.ini.j2
@@ -6,6 +6,8 @@
 
 [testenv:coverage]
 basepython = python3
+allowlist_externals =
+    mkdir
 setenv =
     COVERAGE_PROCESS_START={toxinidir}/.coveragerc
 deps =
@@ -13,6 +15,7 @@ deps =
     coverage-python-version
     zope.testrunner
 commands =
+    mkdir -p {toxinidir}/parts/htmlcov
     coverage erase
 {% if coverage_command %}
     %(coverage_command)s

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -187,7 +187,7 @@ testenv_additional = meta_cfg['tox'].get('testenv-additional', [])
 testenv_commands_pre = meta_cfg['tox'].get('testenv-commands-pre', [])
 testenv_commands = meta_cfg['tox'].get('testenv-commands', [])
 fail_under = meta_cfg['coverage'].setdefault('fail-under', 0)
-coverage_command = meta_cfg['coverage'].get('tox-ini-command', '')
+coverage_command = meta_cfg['tox'].get('coverage-command', '')
 copy_with_meta(
     'tox.ini.j2', path / 'tox.ini', config_type,
     fail_under=fail_under, with_pypy=with_pypy,

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -76,6 +76,7 @@ parser.add_argument(
      choices=[
         'buildout-recipe',
         'pure-python',
+        'zope-product',
     ],
     default=None,
     dest='type',
@@ -156,11 +157,13 @@ additional_check_manifest_ignores = meta_cfg['check-manifest'].get(
     'additional-ignores', [])
 check_manifest_ignore_bad_ideas = meta_cfg['check-manifest'].get(
     'ignore-bad-ideas', [])
+isort_known_first_party = meta_cfg['isort'].get('known_first_party', '')
 copy_with_meta(
     'setup.cfg.j2', path / 'setup.cfg', config_type,
     additional_flake8_config=additional_flake8_config,
     additional_check_manifest_ignores=additional_check_manifest_ignores,
     check_manifest_ignore_bad_ideas=check_manifest_ignore_bad_ideas,
+    isort_known_first_party=isort_known_first_party,
     with_docs=with_docs, with_sphinx_doctests=with_sphinx_doctests)
 copy_with_meta('editorconfig', path / '.editorconfig', config_type)
 copy_with_meta('gitignore', path / '.gitignore', config_type)
@@ -181,12 +184,18 @@ elif (path / '.coveragerc').exists():
 coverage_run_additional_config = meta_cfg['coverage-run'].get(
     'additional-config', [])
 testenv_additional = meta_cfg['tox'].get('testenv-additional', [])
+testenv_commands_pre = meta_cfg['tox'].get('testenv-commands-pre', [])
+testenv_commands = meta_cfg['tox'].get('testenv-commands', [])
 fail_under = meta_cfg['coverage'].setdefault('fail-under', 0)
+coverage_command = meta_cfg['coverage'].get('tox-ini-command', '')
 copy_with_meta(
     'tox.ini.j2', path / 'tox.ini', config_type,
     fail_under=fail_under, with_pypy=with_pypy,
     with_legacy_python=with_legacy_python,
     testenv_additional=testenv_additional,
+    testenv_commands_pre=testenv_commands_pre,
+    testenv_commands=testenv_commands,
+    coverage_command=coverage_command,
     with_docs=with_docs, with_sphinx_doctests=with_sphinx_doctests,
     coverage_run_additional_config=coverage_run_additional_config)
 

--- a/config/default/gitignore
+++ b/config/default/gitignore
@@ -16,7 +16,6 @@ develop-eggs/
 dist/
 docs/_build
 eggs/
-htmlcov/
 lib/
 lib64
 parts/

--- a/config/default/setup.cfg.j2
+++ b/config/default/setup.cfg.j2
@@ -7,6 +7,10 @@ doctests = 1
 # provided to doctests by buildoutSetUp()
 builtins = write, system, cat, join
 {% endif %}
+{% if config_type == 'zope-product' %}
+no-accept-encodings = True
+htmldir = parts/flake8
+{% endif %}
 {% for line in additional_flake8_config %}
 %(line)s
 {% endfor %}
@@ -29,4 +33,17 @@ ignore-bad-ideas =
   {% for line in check_manifest_ignore_bad_ideas %}
     %(line)s
   {% endfor %}
+{% endif %}
+{% if config_type == 'zope-product' %}
+
+[isort]
+force_single_line = True
+combine_as_imports = True
+sections = FUTURE,STDLIB,THIRDPARTY,ZOPE,FIRSTPARTY,LOCALFOLDER
+known_first_party = %(isort_known_first_party)s
+known_third_party = six, docutils, pkg_resources
+known_zope =
+default_section = ZOPE
+line_length = 79
+lines_after_imports = 2
 {% endif %}

--- a/config/default/tox-coverage-config.j2
+++ b/config/default/tox-coverage-config.j2
@@ -1,0 +1,22 @@
+
+[coverage:run]
+branch = True
+plugins = coverage_python_version
+source = src
+{% for line in coverage_run_additional_config %}
+%(line)s
+{% endfor %}
+
+[coverage:report]
+precision = 2
+exclude_lines =
+    pragma: no cover
+    pragma: nocover
+    except ImportError:
+    raise NotImplementedError
+    if __name__ == '__main__':
+    self.fail
+    raise AssertionError
+
+[coverage:html]
+directory = htmlcov

--- a/config/default/tox-coverage-config.j2
+++ b/config/default/tox-coverage-config.j2
@@ -19,4 +19,4 @@ exclude_lines =
     raise AssertionError
 
 [coverage:html]
-directory = {toxinidir}/parts/htmlcov
+directory = parts/htmlcov

--- a/config/default/tox-coverage-config.j2
+++ b/config/default/tox-coverage-config.j2
@@ -19,4 +19,4 @@ exclude_lines =
     raise AssertionError
 
 [coverage:html]
-directory = htmlcov
+directory = {toxinidir}/parts/htmlcov

--- a/config/default/tox-docs.j2
+++ b/config/default/tox-docs.j2
@@ -2,6 +2,7 @@
 
 [testenv:docs]
 basepython = python3
+deps =
 {% if not with_sphinx_doctests %}
 extras =
     docs

--- a/config/default/tox-envlist.j2
+++ b/config/default/tox-envlist.j2
@@ -1,4 +1,5 @@
 [tox]
+minversion = 3.18
 envlist =
     lint
 {% if with_legacy_python %}

--- a/config/default/tox-testenv.j2
+++ b/config/default/tox-testenv.j2
@@ -3,6 +3,12 @@
 usedevelop = true
 deps =
     zope.testrunner
+{% if testenv_commands_pre %}
+commands_pre =
+  {% for line in testenv_commands_pre %}
+    %(line)s
+  {% endfor %}
+{% endif %}
 commands =
     zope-testrunner --test-path=src []
 {% if with_sphinx_doctests %}

--- a/config/pure-python/packages.txt
+++ b/config/pure-python/packages.txt
@@ -52,3 +52,7 @@ zc.intid
 zc.queue
 zope.apidoc
 zope.app.authentication
+zope.app.basicskin
+zope.app.catalog
+zope.app.content
+zope.app.error

--- a/config/pure-python/tox.ini.j2
+++ b/config/pure-python/tox.ini.j2
@@ -6,11 +6,14 @@
 
 [testenv:coverage]
 basepython = python3
+allowlist_externals =
+    mkdir
 deps =
     coverage
     coverage-python-version
     zope.testrunner
 commands =
+    mkdir -p {toxinidir}/parts/htmlcov
 {% if coverage_command %}
     %(coverage_command)s
 {% else %}

--- a/config/pure-python/tox.ini.j2
+++ b/config/pure-python/tox.ini.j2
@@ -11,31 +11,14 @@ deps =
     coverage-python-version
     zope.testrunner
 commands =
+{% if coverage_command %}
+    %(coverage_command)s
+{% else %}
     coverage run -m zope.testrunner --test-path=src []
+{% endif %}
 {% if with_sphinx_doctests %}
     coverage run -a -m sphinx -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
 {% endif %}
     coverage html
     coverage report -m --fail-under=%(fail_under)s
-
-[coverage:run]
-branch = True
-plugins = coverage_python_version
-source = src
-{% for line in coverage_run_additional_config %}
-%(line)s
-{% endfor %}
-
-[coverage:report]
-precision = 2
-exclude_lines =
-    pragma: no cover
-    pragma: nocover
-    except ImportError:
-    raise NotImplementedError
-    if __name__ == '__main__':
-    self.fail
-    raise AssertionError
-
-[coverage:html]
-directory = htmlcov
+{% include 'tox-coverage-config.j2' %}

--- a/config/zope-product/packages.txt
+++ b/config/zope-product/packages.txt
@@ -3,3 +3,4 @@
 # described in README.rst
 Products.MailHost
 Products.GenericSetup
+Products.ZCatalog

--- a/config/zope-product/packages.txt
+++ b/config/zope-product/packages.txt
@@ -1,0 +1,4 @@
+# Packages configured as Zope Product are listed here.
+# Do not edit the file by hand but use the script config-package.py as
+# described in README.rst
+Products.MailHost

--- a/config/zope-product/packages.txt
+++ b/config/zope-product/packages.txt
@@ -2,3 +2,4 @@
 # Do not edit the file by hand but use the script config-package.py as
 # described in README.rst
 Products.MailHost
+Products.GenericSetup

--- a/config/zope-product/tox.ini.j2
+++ b/config/zope-product/tox.ini.j2
@@ -20,7 +20,7 @@ commands =
     %(line)s
   {% endfor %}
 {% else %}
-    {envbindir}/test -v []
+    {envbindir}/test {posargs:-cv}
 {% endif %}
 
 [testenv:lint]
@@ -69,7 +69,7 @@ commands =
 {% if coverage_command %}
     %(coverage_command)s
 {% else %}
-    coverage run {envbindir}/test -v []
+    coverage run {envbindir}/test {posargs:-cv}
 {% endif %}
     coverage html
     coverage report -m --fail-under=%(fail_under)s

--- a/config/zope-product/tox.ini.j2
+++ b/config/zope-product/tox.ini.j2
@@ -44,7 +44,6 @@ deps =
     flake8-html
     # Useful flake8 plugins that are Python and Plone specific:
     flake8-coding
-    flake8-commas
     flake8-debugger
     flake8-string-format
     mccabe
@@ -61,11 +60,14 @@ commands =
 [testenv:coverage]
 basepython = python3
 skip_install = true
+allowlist_externals =
+    mkdir
 deps =
     {[testenv]deps}
     coverage
     coverage-python-version
 commands =
+    mkdir -p {toxinidir}/parts/htmlcov
 {% if coverage_command %}
     %(coverage_command)s
 {% else %}

--- a/config/zope-product/tox.ini.j2
+++ b/config/zope-product/tox.ini.j2
@@ -1,0 +1,76 @@
+{% set with_coverage = True %}
+{% include 'tox-envlist.j2' %}
+
+[testenv]
+skip_install = true
+deps =
+    zc.buildout
+commands_pre =
+{% if testenv_commands_pre %}
+  {% for line in testenv_commands_pre %}
+    %(line)s
+  {% endfor %}
+{% else %}
+    py27,py35: {envbindir}/buildout -nc {toxinidir}/buildout4.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
+    !py27-!py35: {envbindir}/buildout -nc {toxinidir}/buildout.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
+{% endif %}
+commands =
+{% if testenv_commands %}
+  {% for line in testenv_commands %}
+    %(line)s
+  {% endfor %}
+{% else %}
+    {envbindir}/test -v []
+{% endif %}
+
+[testenv:lint]
+basepython = python3
+allowlist_externals =
+    mkdir
+commands_pre =
+    mkdir -p {toxinidir}/parts/flake8
+commands =
+    - isort --check-only --diff {toxinidir}/src setup.py
+    - flake8 --format=html src setup.py
+    flake8 src setup.py
+    check-manifest
+    check-python-versions
+deps =
+    check-manifest
+    check-python-versions
+    flake8
+    isort
+    # helper to generate HTML reports:
+    flake8-html
+    # Useful flake8 plugins that are Python and Plone specific:
+    flake8-coding
+    flake8-commas
+    flake8-debugger
+    flake8-string-format
+    mccabe
+
+[testenv:isort-apply]
+basepython = python3
+commands_pre =
+deps =
+    isort
+commands =
+    isort {toxinidir}/src setup.py []
+{% include 'tox-docs.j2' %}
+
+[testenv:coverage]
+basepython = python3
+skip_install = true
+deps =
+    {[testenv]deps}
+    coverage
+    coverage-python-version
+commands =
+{% if coverage_command %}
+    %(coverage_command)s
+{% else %}
+    coverage run {envbindir}/test -v []
+{% endif %}
+    coverage html
+    coverage report -m --fail-under=%(fail_under)s
+{% include 'tox-coverage-config.j2' %}

--- a/config/zope-product/tox.ini.j2
+++ b/config/zope-product/tox.ini.j2
@@ -30,9 +30,9 @@ allowlist_externals =
 commands_pre =
     mkdir -p {toxinidir}/parts/flake8
 commands =
-    - isort --check-only --diff {toxinidir}/src setup.py
-    - flake8 --format=html src setup.py
-    flake8 src setup.py
+    - isort --check-only --diff {toxinidir}/src {toxinidir}/setup.py
+    - flake8 --format=html {toxinidir}/src {toxinidir}/setup.py
+    flake8 {toxinidir}/src {toxinidir}/setup.py
     check-manifest
     check-python-versions
 deps =
@@ -55,7 +55,7 @@ commands_pre =
 deps =
     isort
 commands =
-    isort {toxinidir}/src setup.py []
+    isort {toxinidir}/src {toxinidir}/setup.py []
 {% include 'tox-docs.j2' %}
 
 [testenv:coverage]


### PR DESCRIPTION
This means we now support a new type which uses `zc.buildout` to install the package under test.

See https://github.com/zopefoundation/Products.MailHost/pull/39 as an example built with this new type.