### PR TITLE
Add ability to define additional tox environments.

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -180,13 +180,17 @@ updated. Example:
         ]
 
     [tox]
+    additional-envlist = [
+        "py37-slim",
+        "py38-fat",
+        ]
     testenv-commands-pre = [
         "{envbindir}/buildout -c ...",
-    ]
+        ]
     testenv-commands = [
         "{envbindir}/test {posargs:-cv}",
         "{envbindir}/test_with_gs {posargs:-cv}",
-    ]
+        ]
     testenv-additional = [
         "setenv =",
         "    ZOPE_INTERFACE_STRICT_IRO=1",
@@ -221,9 +225,12 @@ updated. Example:
     known_first_party = "Products.GenericSetup, Products.CMFCore"
 
     [github-actions]
+    additional-config = [
+        "- [\"3.8\",   \"py38-slim\"]",
+        ]
     additional-install = [
         "sudo apt-get update && sudo apt-get install -y libxml2-dev libxslt-dev"
-    ]
+        ]
 
 Meta Options
 ````````````
@@ -278,6 +285,12 @@ tox.ini options
 ```````````````
 
 The corresponding section is named: ``[tox]``.
+
+additional-envlist
+  This option contains additional entries for the ``envlist`` in ``tox.ini``.
+  The configuration for the needed additional environments can be added using
+  ``testenv-additional`` (see below). This option has to be a list of strings
+  without indentation.
 
 testenv-commands-pre
   Replacement for the default ``commands_pre`` option in ``[testenv]`` of
@@ -350,6 +363,10 @@ GitHub Actions options
 ``````````````````````
 
 The corresponding section is named: ``[github-actions]``.
+
+additional-config
+  Additional entries for the config matrix. This option has to be a list of
+  strings without leading whitespace but it has to start with a hyphen.
 
 additional-install
   Additional lines to be executed during the install dependencies step when

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -183,6 +183,7 @@ elif (path / '.coveragerc').exists():
 
 coverage_run_additional_config = meta_cfg['coverage-run'].get(
     'additional-config', [])
+additional_envlist = meta_cfg['tox'].get('additional-envlist', [])
 testenv_additional = meta_cfg['tox'].get('testenv-additional', [])
 testenv_commands_pre = meta_cfg['tox'].get('testenv-commands-pre', [])
 testenv_commands = meta_cfg['tox'].get('testenv-commands', [])
@@ -192,6 +193,7 @@ copy_with_meta(
     'tox.ini.j2', path / 'tox.ini', config_type,
     fail_under=fail_under, with_pypy=with_pypy,
     with_legacy_python=with_legacy_python,
+    additional_envlist=additional_envlist,
     testenv_additional=testenv_additional,
     testenv_commands_pre=testenv_commands_pre,
     testenv_commands=testenv_commands,
@@ -201,10 +203,15 @@ copy_with_meta(
 
 gha_additional_install = meta_cfg['github-actions'].get(
     'additional-install', [])
+gha_additional_config = meta_cfg['github-actions'].get(
+    'additional-config', [])
 copy_with_meta(
     'tests.yml.j2', workflows / 'tests.yml', config_type,
     with_pypy=with_pypy, with_legacy_python=with_legacy_python,
-    with_docs=with_docs, gha_additional_install=gha_additional_install)
+    with_docs=with_docs,
+    gha_additional_config=gha_additional_config,
+    gha_additional_install=gha_additional_install
+)
 
 
 # Modify MANIFEST.in with meta options

--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -32,6 +32,9 @@ jobs:
         - ["3.8",   "docs"]
 {% endif %}
         - ["3.8",   "coverage"]
+{% for line in gha_additional_config %}
+        %(line)s
+{% endfor %}
 
     runs-on: ubuntu-latest
     name: ${{ matrix.config[1] }}

--- a/config/default/tox-envlist.j2
+++ b/config/default/tox-envlist.j2
@@ -22,3 +22,6 @@ envlist =
 {% if with_coverage %}
     coverage
 {% endif %}
+{% for line in additional_envlist %}
+    %(line)s
+{% endfor %}

--- a/config/pure-python/packages.txt
+++ b/config/pure-python/packages.txt
@@ -79,3 +79,7 @@ zope.renderer
 z3c.preference
 zope.preference
 z3c.formwidget.query
+zc.form
+MultiMapping
+z3c.etestbrowser
+z3c.breadcrumb


### PR DESCRIPTION
This includes the ability to run them via GHA.

See https://github.com/zopefoundation/zc.form/pull/7 making use of these changes.