### PR TITLE
Pin the version of `setuptools` until `zc.buildout = 3.0` is released.

### DIFF
--- a/config/zope-product/tox.ini.j2
+++ b/config/zope-product/tox.ini.j2
@@ -3,7 +3,9 @@
 
 [testenv]
 skip_install = true
+# We need to pin setuptools until we have zc.buildout 3.0.
 deps =
+    setuptools < 52
     zc.buildout
 commands_pre =
 {% if testenv_commands_pre %}


### PR DESCRIPTION
`easy_install` is not supported anymore by setuptools.