### PR TITLE
Add option to completely replace the contents of appveyor.yml.

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -253,6 +253,11 @@ updated. Example:
         "- zope-testrunner --test-path=src",
         "- jasmine",
         ]
+    replacement = [
+        "environment:",
+        "  matrix:",
+        "    ...",
+        ]
 
 Meta Options
 ````````````
@@ -428,6 +433,12 @@ install-steps
 test-steps
   Steps to run the tests on AppVeyor. This option has to be a list of strings.
   It defaults to ``["- zope-testrunner --test-path=src"]``.
+
+replacement
+  Replace the whole template of the AppVeyor configuration with the contents of
+  this option. Use this option as last resort if your needed changes are too
+  big to configure AppVeyor in another way. This option has to be a list of
+  strings.
 
 
 Hints

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -237,10 +237,12 @@ if with_appveyor:
         'install-steps', ['- pip install -U -e .[test]'])
     appveyor_test_steps = meta_cfg['appveyor'].get(
         'test-steps', ['- zope-testrunner --test-path=src'])
+    appveyor_replacement = meta_cfg['appveyor'].get('replacement', [])
     copy_with_meta(
         'appveyor.yml.j2', path / 'appveyor.yml', config_type,
         with_legacy_python=with_legacy_python,
         install_steps=appveyor_install_steps, test_steps=appveyor_test_steps,
+        replacement=appveyor_replacement,
     )
 
 

--- a/config/default/appveyor.yml.j2
+++ b/config/default/appveyor.yml.j2
@@ -1,3 +1,8 @@
+{% if replacement %}
+{% for line in replacement %}
+%(line)s
+{% endfor %}
+{% else %}
 environment:
 
   matrix:
@@ -44,3 +49,4 @@ test_script:
 
 on_success:
   - echo Build succesful!
+{% endif %}


### PR DESCRIPTION
This is the only way which makes sense for https://github.com/zopefoundation/Zope/pull/942.
I did not find another way where it does not break.