### PR TITLE
Fix invocation syntax in README

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -85,7 +85,7 @@ The script needs a ``venv`` with some packages installed::
 
 To use the configuration provided here in a package call the following script::
 
-    $ bin/python config-package.py <path-to-package> <config-type-name>
+    $ bin/python config-package.py <path-to-package> --type <config-type-name> [<additional-options>]
 
 See ``--help`` for details.
 


### PR DESCRIPTION
I tried both ways and only one worked.

Fixes #67.