### PR TITLE
Make it possible to configure [testenv] extras

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -184,6 +184,11 @@ updated. Example:
         "py37-slim",
         "py38-fat",
         ]
+    testenv-extras = [
+        "test",
+        "docs",
+        "extra-feature",
+        ]
     testenv-commands-pre = [
         "{envbindir}/buildout -c ...",
         ]
@@ -318,6 +323,10 @@ additional-envlist
   The configuration for the needed additional environments can be added using
   ``testenv-additional`` (see below). This option has to be a list of strings
   without indentation.
+
+testenv-extras
+  Replacement for the default ``extras`` option in ``[testenv]`` of
+  ``tox.ini``.  This option has to be a list of strings without indentation.
 
 testenv-commands-pre
   Replacement for the default ``commands_pre`` option in ``[testenv]`` of

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -6,9 +6,7 @@ from shared.toml_encoder import TomlArraySeparatorEncoderWithNewline
 import argparse
 import collections
 import jinja2
-import os
 import pathlib
-import shutil
 import toml
 
 
@@ -16,6 +14,7 @@ META_HINT = """\
 # Generated from:
 # https://github.com/zopefoundation/meta/tree/master/config/{config_type}
 """
+
 
 def copy_with_meta(template_name, destination, config_type, **kw):
     """Copy the source file to destination and a hint of origin.
@@ -73,7 +72,7 @@ parser.add_argument(
          ' .meta.toml.')
 parser.add_argument(
     '-t', '--type',
-     choices=[
+    choices=[
         'buildout-recipe',
         'pure-python',
         'zope-product',
@@ -190,6 +189,10 @@ elif (path / '.coveragerc').exists():
 
 additional_envlist = meta_cfg['tox'].get('additional-envlist', [])
 testenv_additional = meta_cfg['tox'].get('testenv-additional', [])
+testenv_extras = meta_cfg['tox'].get(
+    'testenv-extras',
+    ['test'] + (['docs'] if with_sphinx_doctests else [])
+)
 testenv_commands_pre = meta_cfg['tox'].get('testenv-commands-pre', [])
 testenv_commands = meta_cfg['tox'].get('testenv-commands', [])
 coverage_command = meta_cfg['tox'].get('coverage-command', '')
@@ -202,6 +205,7 @@ copy_with_meta(
     with_legacy_python=with_legacy_python,
     additional_envlist=additional_envlist,
     testenv_additional=testenv_additional,
+    testenv_extras=testenv_extras,
     testenv_commands_pre=testenv_commands_pre,
     testenv_commands=testenv_commands,
     coverage_command=coverage_command,
@@ -259,7 +263,7 @@ with change_dir(path) as cwd:
     if with_appveyor:
         call('git', 'add', 'appveyor.yml')
     # Remove empty sections:
-    meta_cfg = {k: v  for k, v in meta_cfg.items() if v}
+    meta_cfg = {k: v for k, v in meta_cfg.items() if v}
     with open('.meta.toml', 'w') as meta_f:
         meta_f.write(META_HINT.format(config_type=config_type))
         toml.dump(

--- a/config/default/tox-testenv.j2
+++ b/config/default/tox-testenv.j2
@@ -15,10 +15,9 @@ commands =
     sphinx-build -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
 {% endif %}
 extras =
-    test
-{% if with_sphinx_doctests %}
-    docs
-{% endif %}
+{% for line in testenv_extras %}
+    %(line)s
+{% endfor %}
 {% for line in testenv_additional %}
 %(line)s
 {% endfor %}


### PR DESCRIPTION
Needed for https://github.com/zopefoundation/zope.testrunner/pull/116
where I want to use tox's factors to conditionally enable the 'subunit'
extra for tox environments like py38-subunit.

Apologies for the unrelated flake8 fixes that my editor highlighted to me.