### PR TITLE
Look for `tox` on `$PATH` first, then dive into `bin`

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -98,7 +98,8 @@ The script does the following steps:
 3. Remove a possibly existing ``.coveragerc`` and ``bootstrap.py``. (Coverage
    is now configured in ``tox.ini`` for packages which are no buildout
    recipes.)
-4. Run the tests via: ``tox``
+4. Run the tests via: ``tox``. The ``tox`` script may be either on the current
+   ``$PATH`` or in the ``bin`` subfolder of the current working directory.
 5. Create a branch and a pull request. (Prevent pushing to GitHub using the
    command line switch ``--no-push``.)
 

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -7,6 +7,7 @@ import argparse
 import collections
 import jinja2
 import pathlib
+import shutil
 import toml
 
 
@@ -286,7 +287,8 @@ with change_dir(path) as cwd:
             TomlArraySeparatorEncoderWithNewline(
                 separator=',\n   ', indent_first_line=True))
 
-    call(pathlib.Path(cwd) / 'bin' / 'tox', '-p', 'auto')
+    tox_path = shutil.which('tox') or (pathlib.Path(cwd) / 'bin' / 'tox')
+    call(tox_path, '-p', 'auto')
 
     branches = call(
         'git', 'branch', '--format', '%(refname:short)',


### PR DESCRIPTION
Fixes #73 

The code will look for a `tox` script on the current `$PATH` and fall back to the current working directory's `bin` subfolder.