### PR TITLE
Add option to prevent automatic commits

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -99,8 +99,9 @@ The script does the following steps:
    is now configured in ``tox.ini`` for packages which are no buildout
    recipes.)
 4. Run the tests via: ``tox``
-5. Create a branch and a pull request. (Prevent pushing to GitHub using the
-   command line switch ``--no-push``.)
+5. Create a branch and a pull request. (Prevent an automatic commit of all
+   changes with the command line switch ``--no-commit``, or an automatic push
+   to GitHub using the command line switch ``--no-push``.)
 
 After running the script you should manually do the following steps:
 
@@ -115,6 +116,10 @@ CLI arguments
 +++++++++++++
 
 The following arguments are supported.
+
+--no-commit
+  Don't automatically commit changes after the configuration run. Implies
+  --no-push.
 
 --no-push
   Avoid pushing at the end of the configuration run.

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -32,6 +32,11 @@ parser = argparse.ArgumentParser(
 parser.add_argument(
     'path', type=pathlib.Path, help='path to the repository to be configured')
 parser.add_argument(
+    '--no-commit',
+    dest='no_commit',
+    action='store_true',
+    help='Prevent automatic committing of changes. Implies --no-push.')
+parser.add_argument(
     '--no-push',
     dest='no_push',
     action='store_true',
@@ -297,16 +302,18 @@ with change_dir(path) as cwd:
     else:
         call('git', 'checkout', '-b', branch_name)
         updating = False
-    call('git', 'add',
-         'setup.cfg', 'tox.ini', '.gitignore', '.github/workflows/tests.yml',
-         'MANIFEST.in', '.editorconfig', '.meta.toml')
     if not fail_under:
         print('In .meta.toml in section [coverage] the option "fail-under" is'
               ' 0. Please enter a valid minimum coverage and rerun.')
         abort(1)
-    call('git', 'commit', '-m', f'Configuring for {config_type}')
-    if not args.no_push:
-        call('git', 'push', '--set-upstream', 'origin', branch_name)
+    if not args.no_commit:
+        call('git', 'add',
+             'setup.cfg', 'tox.ini', '.gitignore',
+             '.github/workflows/tests.yml', 'MANIFEST.in', '.editorconfig',
+             '.meta.toml')
+        call('git', 'commit', '-m', f'Configuring for {config_type}')
+        if not args.no_push:
+            call('git', 'push', '--set-upstream', 'origin', branch_name)
     print()
     print('If everything went fine up to here:')
     if updating:

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -36,11 +36,13 @@ parser.add_argument(
     '--no-commit',
     dest='commit',
     action='store_false',
+    default=True,
     help='Prevent automatic committing of changes. Implies --no-push.')
 parser.add_argument(
     '--no-push',
     dest='push',
     action='store_false',
+    default=True,
     help='Prevent direct push.')
 parser.add_argument(
     '--with-appveyor',

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -34,13 +34,13 @@ parser.add_argument(
     'path', type=pathlib.Path, help='path to the repository to be configured')
 parser.add_argument(
     '--no-commit',
-    dest='no_commit',
-    action='store_true',
+    dest='commit',
+    action='store_false',
     help='Prevent automatic committing of changes. Implies --no-push.')
 parser.add_argument(
     '--no-push',
-    dest='no_push',
-    action='store_true',
+    dest='push',
+    action='store_false',
     help='Prevent direct push.')
 parser.add_argument(
     '--with-appveyor',
@@ -308,13 +308,13 @@ with change_dir(path) as cwd:
         print('In .meta.toml in section [coverage] the option "fail-under" is'
               ' 0. Please enter a valid minimum coverage and rerun.')
         abort(1)
-    if not args.no_commit:
+    if args.commit:
         call('git', 'add',
              'setup.cfg', 'tox.ini', '.gitignore',
              '.github/workflows/tests.yml', 'MANIFEST.in', '.editorconfig',
              '.meta.toml')
         call('git', 'commit', '-m', f'Configuring for {config_type}')
-        if not args.no_push:
+        if args.push:
             call('git', 'push', '--set-upstream', 'origin', branch_name)
     print()
     print('If everything went fine up to here:')


### PR DESCRIPTION
Fixes #77 

Adds an option `--no-commit` which prevents the `git add` and `git commit` steps (and implies that nothing will be pushed, either). This makes it easier to inspect the changes or re-run the script without causing more and more commits.
