### PR TITLE
Add option to forego linting

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -119,6 +119,12 @@ The following arguments are supported.
 --no-push
   Avoid pushing at the end of the configuration run.
 
+--no-linting
+  Don't run ``flake8`` and ``isort`` linters over the code. If the code is old
+  and numerous linting changes would obscure the package changes it may make
+  sense to use this flag and run the linters separate from the package
+  conversion.
+
 --branch
   Define a specific git branch name to be created for the changes. By default
   the script creates one which includes the name of the configuration type.

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -292,15 +292,18 @@ with change_dir(path) as cwd:
             TomlArraySeparatorEncoderWithNewline(
                 separator=',\n   ', indent_first_line=True))
 
-    old_toxenv = os.environ.get('TOXENV', None)
-    result = call(pathlib.Path(cwd) / 'bin' / 'tox', '-l',
-                  capture_output=True)
-    tox_envs = result.stdout.split()
-    if args.no_linting and 'lint' in tox_envs:
-        tox_envs.remove('lint')
-    os.environ['TOXENV'] = ','.join(tox_envs)
-    call(pathlib.Path(cwd) / 'bin' / 'tox', '-p', 'auto')
-    os.environ['TOXENV'] = old_toxenv or ''
+    if args.no_linting:
+        old_toxenv = os.environ.get('TOXENV', None)
+        result = call(pathlib.Path(cwd) / 'bin' / 'tox', '-l',
+                      capture_output=True)
+        tox_envs = result.stdout.split()
+        if 'lint' in tox_envs:
+            tox_envs.remove('lint')
+        os.environ['TOXENV'] = ','.join(tox_envs)
+        call(pathlib.Path(cwd) / 'bin' / 'tox', '-p', 'auto')
+        os.environ['TOXENV'] = old_toxenv or ''
+    else:
+        call(pathlib.Path(cwd) / 'bin' / 'tox', '-p', 'auto')
 
     branches = call(
         'git', 'branch', '--format', '%(refname:short)',


### PR DESCRIPTION
Fixes #75 

This PR adds an option `--no-linting` to skip the linting step.

Since linting is part of the `tox` run the solution is a little messy. It involves listing all `tox` environments, removing `lint`,  and then running `tox` with the `TOXENV` environment variable set to the remaining environments