### PR TITLE
Run CI on all branch pushes

### DIFF
--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -3,7 +3,6 @@ name: tests
 on:
   push:
     branches: [ '**' ]
-  pull_request:
   schedule:
     - cron: '0 12 * * 0'  # run once a week on Sunday
 

--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -2,7 +2,7 @@ name: tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ '**' ]
   pull_request:
   schedule:
     - cron: '0 12 * * 0'  # run once a week on Sunday

--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -3,6 +3,7 @@ name: tests
 on:
   push:
     branches: [ '**' ]
+  pull_request:
   schedule:
     - cron: '0 12 * * 0'  # run once a week on Sunday
 

--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -2,7 +2,6 @@ name: tests
 
 on:
   push:
-    branches: [ '**' ]
   pull_request:
   schedule:
     - cron: '0 12 * * 0'  # run once a week on Sunday


### PR DESCRIPTION
Fixes #74 

This change comes closest to the behavior we had before with Travis while avoiding doubling CI checks on pull requests. It runs CI on all branch pushes and omits a separate CI configuration for PRs, which are already fully covered by CI for pushes to the branches they are based on.

