### PR TITLE
Add isort config for known_local_folder

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -445,6 +445,11 @@ known_first_party
   configuration. This option has to be a string. It defaults to the empty
   string.
 
+known_local_folder
+  This option defines the value for ``known_local_folder`` in the ``isort``
+  configuration. This option has to be a string. It defaults to the empty
+  string.
+
 
 GitHub Actions options
 ``````````````````````

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -174,6 +174,8 @@ isort_known_third_party = meta_cfg['isort'].get(
     'known_third_party', 'six, docutils, pkg_resources')
 isort_known_zope = meta_cfg['isort'].get('known_zope', '')
 isort_known_first_party = meta_cfg['isort'].get('known_first_party', '')
+isort_known_local_folder = meta_cfg['isort'].get('known_local_folder', '')
+
 copy_with_meta(
     'setup.cfg.j2', path / 'setup.cfg', config_type,
     additional_flake8_config=additional_flake8_config,
@@ -182,6 +184,7 @@ copy_with_meta(
     isort_known_third_party=isort_known_third_party,
     isort_known_zope=isort_known_zope,
     isort_known_first_party=isort_known_first_party,
+    isort_known_local_folder=isort_known_local_folder,
     with_docs=with_docs, with_sphinx_doctests=with_sphinx_doctests,
     with_legacy_python=with_legacy_python,
 )

--- a/config/default/setup.cfg.j2
+++ b/config/default/setup.cfg.j2
@@ -47,6 +47,7 @@ sections = FUTURE,STDLIB,THIRDPARTY,ZOPE,FIRSTPARTY,LOCALFOLDER
 known_third_party = %(isort_known_third_party)s
 known_zope = %(isort_known_zope)s
 known_first_party = %(isort_known_first_party)s
+known_local_folder = %(isort_known_local_folder)s
 default_section = ZOPE
 line_length = 79
 lines_after_imports = 2


### PR DESCRIPTION
For `Products.Sessions`, which contains two packages, it is necessary to be able to specify the `isort` `known_local_folder` directive.