### PR TITLE
Introduce testenv-deps option

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -357,6 +357,11 @@ testenv-commands
   Replacement for the default ``commands`` option in ``[testenv]`` of
   ``tox.ini``. This option has to be a list of strings without indentation.
 
+testenv-deps
+  Replacement for the default ``deps`` option in ``[testenv]`` of ``tox.ini``.
+  This option has to be a list of strings without indentation.  The default is
+  ``['zope.testrunner']``.
+
 testenv-additional
   Additional lines for the section ``[testenv]`` in ``tox.ini``.
   This option has to be a list of strings.

--- a/config/README.rst
+++ b/config/README.rst
@@ -205,6 +205,9 @@ updated. Example:
         "{envbindir}/test {posargs:-cv}",
         "{envbindir}/test_with_gs {posargs:-cv}",
         ]
+    testenv-deps = [
+        "zope.testrunner",
+        ]
     testenv-additional = [
         "setenv =",
         "    ZOPE_INTERFACE_STRICT_IRO=1",

--- a/config/buildout-recipe/tox.ini.j2
+++ b/config/buildout-recipe/tox.ini.j2
@@ -19,7 +19,9 @@ setenv =
 deps =
     coverage
     coverage-python-version
-    zope.testrunner
+{% for line in testenv_deps %}
+    %(line)s
+{% endfor %}
 commands =
     mkdir -p {toxinidir}/parts/htmlcov
     coverage erase

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -6,7 +6,6 @@ from shared.toml_encoder import TomlArraySeparatorEncoderWithNewline
 import argparse
 import collections
 import jinja2
-import os
 import pathlib
 import shutil
 import toml
@@ -212,6 +211,7 @@ testenv_additional_extras = meta_cfg['tox'].get(
 testenv_commands_pre = meta_cfg['tox'].get('testenv-commands-pre', [])
 testenv_commands = meta_cfg['tox'].get('testenv-commands', [])
 coverage_command = meta_cfg['tox'].get('coverage-command', '')
+testenv_deps = meta_cfg['tox'].get('testenv-deps', ['zope.testrunner'])
 coverage_setenv = meta_cfg['tox'].get('coverage-setenv', [])
 fail_under = meta_cfg['coverage'].setdefault('fail-under', 0)
 coverage_run_additional_config = meta_cfg['coverage-run'].get(
@@ -234,6 +234,7 @@ copy_with_meta(
     testenv_additional_extras=testenv_additional_extras,
     testenv_commands_pre=testenv_commands_pre,
     testenv_commands=testenv_commands,
+    testenv_deps=testenv_deps,
     flake8_additional_sources=flake8_additional_sources,
     coverage_command=coverage_command,
     coverage_setenv=coverage_setenv,

--- a/config/default/tox-testenv.j2
+++ b/config/default/tox-testenv.j2
@@ -2,7 +2,9 @@
 [testenv]
 usedevelop = true
 deps =
-    zope.testrunner
+{% for line in testenv_deps %}
+    %(line)s
+{% endfor %}
 {% if testenv_commands_pre %}
 commands_pre =
   {% for line in testenv_commands_pre %}

--- a/config/pure-python/packages.txt
+++ b/config/pure-python/packages.txt
@@ -99,3 +99,4 @@ gocept.xmlrpcskin
 z3c.objpath
 zc.table
 Products.ExternalEditor
+zope.testrunner

--- a/config/pure-python/tox.ini.j2
+++ b/config/pure-python/tox.ini.j2
@@ -11,7 +11,9 @@ allowlist_externals =
 deps =
     coverage
     coverage-python-version
-    zope.testrunner
+{% for line in testenv_deps %}
+    %(line)s
+{% endfor %}
 {% if coverage_setenv %}
 setenv =
 {% for line in coverage_setenv %}


### PR DESCRIPTION
The one and only use-case of this is to make zope.testrunner's own
tox.ini not depend on zope.testrunner.  I made it a configurable list
for maximum flexibility, which might be a mistake.

~~I haven't tested this code yet.~~

I have tested this on zope.testrunner and it works the way I expect.