### PR TITLE
Prune list of automatically included file types to prevent warnings

### DIFF
--- a/config/default/MANIFEST.in.j2
+++ b/config/default/MANIFEST.in.j2
@@ -10,18 +10,13 @@ include .coveragerc
 {% endif %}
 {% if with_docs %}
 
-recursive-include docs *.bat
 recursive-include docs *.py
 recursive-include docs *.rst
 recursive-include docs *.txt
 recursive-include docs Makefile
 {% endif %}
 
-recursive-include src *.pt
 recursive-include src *.py
-recursive-include src *.rst
-recursive-include src *.txt
-recursive-include src *.zcml
 {% for line in additional_rules %}
 %(line)s
 {% endfor %}


### PR DESCRIPTION
In response to https://github.com/zopefoundation/Products.MIMETools/pull/4#discussion_r595822627

This PR cuts down the number of entries in the `MANIFEST.in` template to the absolute minimum. For example, working with the tool has shown that many Sphinx documentation folders don't bother including a Windows `.bat` file for building, and the only thing that is guaranteed to always exist in a `src` folder is Python files.

With this PR, everything else can be added to the `additional-rules` configuration option in the `.meta.toml` `[manifest]` section.