### PR TITLE
Update repository URL for Flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
           - id: check-yaml
           - id: debug-statements
             language_version: python3
-    - repo: https://gitlab.com/pycqa/flake8
+    - repo: https://github.com/PyCQA/flake8
       rev: 3.8.4
       hooks:
           - id: flake8


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos