### PR TITLE
Add option to set `setenv`.

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -208,9 +208,12 @@ updated. Example:
     testenv-deps = [
         "zope.testrunner",
         ]
+    testenv-setenv = [
+        "ZOPE_INTERFACE_STRICT_IRO=1",
+    ]
     testenv-additional = [
-        "setenv =",
-        "    ZOPE_INTERFACE_STRICT_IRO=1",
+        "passenv =",
+        "    DISPLAY",
         ]
     coverage-command = "coverage run {envbindir}/test_with_gs []"
     coverage-setenv = [
@@ -364,6 +367,11 @@ testenv-deps
   Replacement for the default ``deps`` option in ``[testenv]`` of ``tox.ini``.
   This option has to be a list of strings without indentation.  The default is
   ``['zope.testrunner']``.
+
+testenv-setenv
+  Set the value of the ``setenv`` option in ``[testenv]`` of ``tox.ini``.
+  Depending in the template used this might be an addition to the predefined
+  values for this option. This option has to be a list of strings.
 
 testenv-additional
   Additional lines for the section ``[testenv]`` in ``tox.ini``.

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -213,6 +213,7 @@ testenv_additional_extras = meta_cfg['tox'].get(
     'testenv-additional-extras', [])
 testenv_commands_pre = meta_cfg['tox'].get('testenv-commands-pre', [])
 testenv_commands = meta_cfg['tox'].get('testenv-commands', [])
+testenv_setenv = meta_cfg['tox'].get('testenv-setenv', [])
 coverage_command = meta_cfg['tox'].get('coverage-command', '')
 testenv_deps = meta_cfg['tox'].get('testenv-deps', ['zope.testrunner'])
 coverage_setenv = meta_cfg['tox'].get('coverage-setenv', [])
@@ -238,6 +239,7 @@ copy_with_meta(
     testenv_commands_pre=testenv_commands_pre,
     testenv_commands=testenv_commands,
     testenv_deps=testenv_deps,
+    testenv_setenv=testenv_setenv,
     flake8_additional_sources=flake8_additional_sources,
     coverage_command=coverage_command,
     coverage_setenv=coverage_setenv,

--- a/config/default/tox-testenv.j2
+++ b/config/default/tox-testenv.j2
@@ -5,6 +5,12 @@ deps =
 {% for line in testenv_deps %}
     %(line)s
 {% endfor %}
+{% if testenv_setenv %}
+setenv =
+  {% for line in testenv_setenv %}
+    %(line)s
+  {% endfor %}
+{% endif %}
 {% if testenv_commands_pre %}
 commands_pre =
   {% for line in testenv_commands_pre %}

--- a/config/zope-product/tox.ini.j2
+++ b/config/zope-product/tox.ini.j2
@@ -7,6 +7,12 @@ skip_install = true
 deps =
     setuptools < 52
     zc.buildout
+{% if testenv_setenv %}
+setenv =
+  {% for line in testenv_setenv %}
+    %(line)s
+  {% endfor %}
+{% endif %}
 commands_pre =
 {% if testenv_commands_pre %}
   {% for line in testenv_commands_pre %}


### PR DESCRIPTION
This is needed for zopefoundation/meta#63 aka support packages with C code
and shown in action at https://github.com/zopefoundation/z3c.recipe.compattest/pull/5/commits/dd5105edc032a1392fbb4588e2554ac7e43acdf2