### PR TITLE
Fix tox docs env due to repoze.sphinx.autointerface

### DIFF
--- a/config/default/tox-docs.j2
+++ b/config/default/tox-docs.j2
@@ -3,7 +3,8 @@
 [testenv:docs]
 basepython = python3
 skip_install = false
-deps =
+# Until repoze.sphinx.autointerface supports Sphinx 4.x we cannot use it:
+deps = Sphinx < 4
 {% if not with_sphinx_doctests %}
 extras =
     docs


### PR DESCRIPTION
See https://github.com/repoze/repoze.sphinx.autointerface/issues/16

Needed for
* https://github.com/zopefoundation/zope.browser/pull/16
* https://github.com/zopefoundation/Products.PluggableAuthService/pull/96
* …