### PR TITLE
Ignore htmlcov/

### DIFF
--- a/config/default/gitignore
+++ b/config/default/gitignore
@@ -19,6 +19,7 @@ dist/
 docs/_build
 eggs/
 etc/
+htmlcov/
 lib/
 lib64
 log/


### PR DESCRIPTION
Several repositories that use pure-python (e.g. zope.browser, zc.queue) leave htmlcov/ directories lying around.