### PR TITLE
Do not run Sphinx doctests on legacy Python as they might fail.

### DIFF
--- a/config/default/tox-testenv.j2
+++ b/config/default/tox-testenv.j2
@@ -30,7 +30,11 @@ commands =
     zope-testrunner --test-path=src {posargs:-vc}
 {% endif %}
 {% if with_sphinx_doctests %}
+  {% if with_legacy_python %}
+    !py27-!pypy: sphinx-build -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
+  {% else %}
     sphinx-build -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
+  {% endif %}
 {% endif %}
 extras =
     test


### PR DESCRIPTION
Needed for https://github.com/zopefoundation/zope.configuration/pull/54