### PR TITLE
Preserve [tox] flake8

### DIFF
--- a/config/config-package.py
+++ b/config/config-package.py
@@ -58,6 +58,7 @@ parser.add_argument(
     '--no-flake8',
     dest='use_flake8',
     action='store_false',
+    default=None,
     help='Do not include flake8 and isort in the linting configuration.')
 parser.add_argument(
     '--with-appveyor',


### PR DESCRIPTION
Currently if you run config-package.py with no arguments, it'll always
set [tox] flake8 = true instead of preserving the existing value.