### PR TITLE
Allow to test against the non-final Python 3.10 version.

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -152,6 +152,11 @@ The following options are only needed one time as their values re stored in
 --with-pypy
   Enable PyPy support.
 
+--with-future-python
+  The package supports the next upcoming Python version which does not yet have
+  a final release thus it is not yet generally supported by the zopefoundation
+  packages.
+
 --without-legacy-python
   The package does not support Python versions which reached their end-of-life.
   (Currently this means dropping support for Python 2.7 and 3.5.) This as well

--- a/config/c-code/manylinux-install.sh.j2
+++ b/config/c-code/manylinux-install.sh.j2
@@ -28,6 +28,9 @@ for PYBIN in /opt/python/*/bin; do
        [[ "${PYBIN}" == *"cp36"* ]] || \
        [[ "${PYBIN}" == *"cp37"* ]] || \
        [[ "${PYBIN}" == *"cp38"* ]] || \
+{% if with_future_python %}
+       [[ "${PYBIN}" == *"cp310"* ]] || \
+{% endif %}
        [[ "${PYBIN}" == *"cp39"* ]]; then
         "${PYBIN}/pip" install -e /io/
         "${PYBIN}/pip" wheel /io/ -w wheelhouse/

--- a/config/c-code/tests-strategy.j2
+++ b/config/c-code/tests-strategy.j2
@@ -16,7 +16,7 @@
           - 3.8
           - 3.9
 {% if with_future_python %}
-          - 3.10
+          - 3.10.0-beta.3
 {% endif %}
         os: [ubuntu-20.04, macos-latest]
 {% if with_pypy or with_legacy_python %}

--- a/config/c-code/tests-strategy.j2
+++ b/config/c-code/tests-strategy.j2
@@ -15,6 +15,9 @@
           - 3.7
           - 3.8
           - 3.9
+{% if with_future_python %}
+          - 3.10
+{% endif %}
         os: [ubuntu-20.04, macos-latest]
 {% if with_pypy or with_legacy_python %}
         exclude:

--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -256,13 +256,13 @@ jobs:
         # The 2010 image is the most recent spec that comes with Python 2.7,
         # and only up through the tag 2021-02-06-3d322a5
         env:
-          DOCKER_IMAGE: quay.io/pypa/${{ matrix.image }}:2021-02-06-3d322a5
+          DOCKER_IMAGE: quay.io/pypa/${{ matrix.image }}
         run: |
           bash .manylinux.sh
       - name: Build %(package_name)s (i686)
         if: matrix.image == 'manylinux2010_i686'
         env:
-          DOCKER_IMAGE: quay.io/pypa/${{ matrix.image }}:2021-02-06-3d322a5
+          DOCKER_IMAGE: quay.io/pypa/${{ matrix.image }}
           PRE_CMD: linux32
         run: |
           bash .manylinux.sh

--- a/config/c-code/tox.ini.j2
+++ b/config/c-code/tox.ini.j2
@@ -14,6 +14,9 @@ envlist =
     py37,py37-pure
     py38,py38-pure
     py39,py39-pure
+{% if with_future_python %}
+    py310,py310-pure
+{% endif %}
 {% if with_pypy and with_legacy_python %}
     pypy
 {% endif %}

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -81,6 +81,13 @@ parser.add_argument(
     default=False,
     help='Activate PyPy support if not already configured in .meta.toml.')
 parser.add_argument(
+    '--with-future-python',
+    dest='with_future_python',
+    action='store_true',
+    default=False,
+    help='Activate support for a future non-final Python version if not'
+         ' already configured in .meta.toml.')
+parser.add_argument(
     '--without-legacy-python',
     dest='with_legacy_python',
     action='store_false',
@@ -183,6 +190,9 @@ with_windows = meta_cfg['python'].get(
 meta_cfg['python']['with-windows'] = with_windows
 with_pypy = meta_cfg['python'].get('with-pypy', False) or args.with_pypy
 meta_cfg['python']['with-pypy'] = with_pypy
+with_future_python = (meta_cfg['python'].get('with-future-python', False)
+                      or args.with_future_python)
+meta_cfg['python']['with-future-python'] = with_future_python
 if args.with_legacy_python is None:
     with_legacy_python = meta_cfg['python'].get('with-legacy-python', True)
 else:
@@ -257,6 +267,7 @@ if (config_type_path / 'manylinux.sh').exists():
     copy_with_meta(
         'manylinux-install.sh.j2', path / '.manylinux-install.sh', config_type,
         package_name=path.name,
+        with_future_python=with_future_python,
     )
     (path / '.manylinux-install.sh').chmod(0o755)
     add_manylinux = True
@@ -308,6 +319,7 @@ copy_with_meta(
     use_flake8=use_flake8,
     with_docs=with_docs,
     with_legacy_python=with_legacy_python,
+    with_future_python=with_future_python,
     with_pypy=with_pypy,
     with_sphinx_doctests=with_sphinx_doctests,
 )
@@ -331,6 +343,7 @@ copy_with_meta(
     steps_before_checkout=gha_steps_before_checkout,
     with_docs=with_docs,
     with_legacy_python=with_legacy_python,
+    with_future_python=with_future_python,
     with_pypy=with_pypy,
     with_windows=with_windows,
 )
@@ -363,6 +376,7 @@ if with_appveyor:
     copy_with_meta(
         'appveyor.yml.j2', path / 'appveyor.yml', config_type,
         with_legacy_python=with_legacy_python,
+        with_future_python=with_future_python,
         global_env_vars=appveyor_global_env_vars,
         additional_matrix=appveyor_additional_matrix,
         install_steps=appveyor_install_steps, test_steps=appveyor_test_steps,

--- a/config/default/appveyor.yml.j2
+++ b/config/default/appveyor.yml.j2
@@ -23,6 +23,10 @@ environment:
     - python: 38-x64
     - python: 39
     - python: 39-x64
+{% if with_future_python %}
+    - python: 310
+    - python: 310-x64
+{% endif %}
 {% for line in additional_matrix %}
     %(line)s
 {% endfor %}

--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -36,6 +36,9 @@ jobs:
         - ["3.7",   "py37"]
         - ["3.8",   "py38"]
         - ["3.9",   "py39"]
+{% if with_future_python %}
+        - ["3.10.0-beta.3",  "py310"]
+{% endif %}
 {% if with_pypy and with_legacy_python %}
         - ["pypy2", "pypy"]
 {% endif %}

--- a/config/default/tox-envlist.j2
+++ b/config/default/tox-envlist.j2
@@ -10,6 +10,9 @@ envlist =
     py37
     py38
     py39
+{% if with_future_python %}
+    py310
+{% endif %}
 {% if with_pypy and with_legacy_python %}
     pypy
 {% endif %}

--- a/config/default/tox-lint.j2
+++ b/config/default/tox-lint.j2
@@ -7,10 +7,14 @@ deps =
     flake8
 {% endif %}
     check-manifest
+{% if not with_future_python %}
     check-python-versions
+{% endif %}
 commands =
 {% if use_flake8 %}
     flake8 src setup.py%(flake8_additional_sources)s
 {% endif %}
     check-manifest
+{% if not with_future_python %}
     check-python-versions
+{% endif %}


### PR DESCRIPTION
This PR was used for

* https://github.com/zopefoundation/Missing/pull/8
* https://github.com/zopefoundation/ExtensionClass/pull/35

(I did only try it with the `pure-python` and `c-code` types, yet).

`check-python-versions` is omitted because of https://github.com/mgedmin/check-python-versions/issues/28