### PR TITLE
Script to re-enable GitHub Actions.

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -633,10 +633,7 @@ Re-enabling GitHub Actions
 After a certain period of time (currently 60 days) without commits GitHub
 automatically disables Actions. They can be re-enabled manually per repository.
 There is a script to do this for all repositories. It does no harm if Actions
-is already enabled.
-
-.. caution:: This script automatically clones all repositories which are
-             configured using the ``config-package.py`` script.
+is already enabled for a repository.
 
 Preparation
 +++++++++++

--- a/config/README.rst
+++ b/config/README.rst
@@ -651,7 +651,6 @@ Preparation
 Usage
 +++++
 
-To run the script point it to a directory where you store clones of the
-zopefoundation repositories::
+To run the script just call it::
 
-    $ bin/python re-enable-actions.py <path-to-clones>
+    $ bin/python re-enable-actions.py

--- a/config/README.rst
+++ b/config/README.rst
@@ -625,3 +625,33 @@ The script does the following steps:
 
   Running this script discards any uncommitted changes in the repositories it
   runs on! There is no undo for this operation.
+
+
+Re-enabling GitHub Actions
+--------------------------
+
+After a certain period of time (currently 60 days) without commits GitHub
+automatically disables Actions. They can be re-enabled manually per repository.
+There is a script to do this for all repositories. It does no harm if Actions
+is already enabled.
+
+.. caution:: This script automatically clones all repositories which are
+             configured using the ``config-package.py`` script.
+
+Preparation
++++++++++++
+
+* Install GitHub's CLI application, see https://github.com/cli/cli.
+
+* Authorize using the application:
+
+  - ``gh auth login``
+  - It is probably enough to do it once.
+
+Usage
++++++
+
+To run the script point it to a directory where you store clones of the
+zopefoundation repositories::
+
+    $ bin/python re-enable-actions.py <path-to-clones>

--- a/config/multi-call.py
+++ b/config/multi-call.py
@@ -1,28 +1,10 @@
 #!/usr/bin/env python3
 from shared.call import call
+from shared.packages import list_packages
 from shared.path import change_dir
+from shared.path import path_factory
 import argparse
-import pathlib
 import sys
-
-
-def path_factory(parameter_name, *, has_extension=None, is_dir=False):
-    """Return factory creating pathlib.Path object if requirements are matched.
-
-    The factory raises an exception otherwise.
-    """
-    def factory(str):
-        path = pathlib.Path(str)
-        if not path.exists():
-            raise argparse.ArgumentTypeError(f'{str!r} does not exist!')
-        if has_extension is not None and path.suffix != has_extension:
-            raise argparse.ArgumentTypeError(
-                f'The required extension is {has_extension!r}'
-                f' not {path.suffix!r}.')
-        if is_dir and not path.is_dir():
-            raise argparse.ArgumentTypeError('has to point to a directory!')
-        return path
-    return factory
 
 
 parser = argparse.ArgumentParser(
@@ -42,12 +24,7 @@ parser.add_argument(
 
 # idea from https://stackoverflow.com/a/37367814/8531312
 args, sub_args = parser.parse_known_args()
-
-packages = [
-    p
-    for p in args.packages_txt.read_text().split('\n')
-    if p and not p.startswith('#')
-]
+packages = list_packages(args.packages_txt)
 
 for package in packages:
     print(f'*** Running {args.script.name} on {package} ***')

--- a/config/re-enable-actions.py
+++ b/config/re-enable-actions.py
@@ -1,0 +1,55 @@
+#!/bin/env python3
+from shared.call import call
+from shared.packages import list_packages
+from shared.path import change_dir
+from shared.path import path_factory
+import argparse
+import itertools
+import pathlib
+
+
+base_url = 'https://github.com/zopefoundation'
+base_path = pathlib.Path(__file__).parent
+types = ['buildout-recipe', 'c-code', 'pure-python', 'zope-product']
+
+
+parser = argparse.ArgumentParser(
+    description='Re-enable GitHub Actions for all repos in a packages.txt'
+                ' files.')
+parser.add_argument(
+    'clones',
+    type=path_factory('clones', is_dir=True),
+    help='path to the directory where the clones of the repositories are'
+         ' stored')
+parser.add_argument(
+    '--force-run',
+    help='Run workflow even it is already enabled.',
+    action='store_true')
+
+args = parser.parse_args()
+clones_path = args.clones
+repos = itertools.chain(
+    *[list_packages(base_path / type / 'packages.txt')
+      for type in types])
+
+for repo in repos:
+    print(repo)
+    target_path = clones_path / repo
+    if not target_path.exists():
+        print('    ➡️  Cloning repos ...')
+        with change_dir(clones_path):
+            call('git', 'clone', f'{base_url}/{repo}.git')
+    with change_dir(target_path):
+        wfs = call(
+            'gh', 'workflow', 'list', '--all', capture_output=True).stdout
+        test_line = [x for x in wfs.splitlines() if x.startswith('test')][0]
+        if 'disabled_inactivity' not in test_line:
+            print('    ☑️  already enabled')
+            if args.force_run:
+                call('gh', 'workflow', 'run', 'tests.yml')
+                print("Started workflow.")
+            continue
+        test_id = test_line.split()[-1]
+        call('gh', 'workflow', 'enable', test_id)
+        call('gh', 'workflow', 'run', 'tests.yml')
+        print('    ✅ enabled')

--- a/config/re-enable-actions.py
+++ b/config/re-enable-actions.py
@@ -1,14 +1,13 @@
 #!/bin/env python3
 from shared.call import call
 from shared.packages import list_packages
-from shared.path import change_dir
-from shared.path import path_factory
 import argparse
 import itertools
 import pathlib
 
 
-base_url = 'https://github.com/zopefoundation'
+org = 'zopefoundation'
+base_url = f'https://github.com/{org}'
 base_path = pathlib.Path(__file__).parent
 types = ['buildout-recipe', 'c-code', 'pure-python', 'zope-product']
 
@@ -17,39 +16,40 @@ parser = argparse.ArgumentParser(
     description='Re-enable GitHub Actions for all repos in a packages.txt'
                 ' files.')
 parser.add_argument(
-    'clones',
-    type=path_factory('clones', is_dir=True),
-    help='path to the directory where the clones of the repositories are'
-         ' stored')
-parser.add_argument(
     '--force-run',
     help='Run workflow even it is already enabled.',
     action='store_true')
 
 args = parser.parse_args()
-clones_path = args.clones
 repos = itertools.chain(
     *[list_packages(base_path / type / 'packages.txt')
       for type in types])
 
+
+def run_workflow(base_url, org, repo):
+    """Manually start the tests.yml workflow of a repository."""
+    result = call('gh', 'workflow', 'run', 'tests.yml', '-R', f'{org}/{repo}')
+    if result.returncode != 0:
+        print('To enable manually starting workflows clone the repository'
+              ' and run meta/config/config-package.py on it.')
+        print('Command to clone:')
+        print(f'git clone {base_url}/{repo}.git')
+        return False
+    return True
+
+
 for repo in repos:
     print(repo)
-    target_path = clones_path / repo
-    if not target_path.exists():
-        print('    ➡️  Cloning repos ...')
-        with change_dir(clones_path):
-            call('git', 'clone', f'{base_url}/{repo}.git')
-    with change_dir(target_path):
-        wfs = call(
-            'gh', 'workflow', 'list', '--all', capture_output=True).stdout
-        test_line = [x for x in wfs.splitlines() if x.startswith('test')][0]
-        if 'disabled_inactivity' not in test_line:
-            print('    ☑️  already enabled')
-            if args.force_run:
-                call('gh', 'workflow', 'run', 'tests.yml')
-                print("Started workflow.")
-            continue
-        test_id = test_line.split()[-1]
-        call('gh', 'workflow', 'enable', test_id)
-        call('gh', 'workflow', 'run', 'tests.yml')
+    wfs = call(
+        'gh', 'workflow', 'list', '--all', '-R', f'{org}/{repo}',
+        capture_output=True).stdout
+    test_line = [x for x in wfs.splitlines() if x.startswith('test')][0]
+    if 'disabled_inactivity' not in test_line:
+        print('    ☑️  already enabled')
+        if args.force_run:
+            run_workflow(base_url, org, repo)
+        continue
+    test_id = test_line.split()[-1]
+    call('gh', 'workflow', 'enable', test_id, '-R', f'{org}/{repo}')
+    if run_workflow(base_url, org, repo):
         print('    ✅ enabled')

--- a/config/shared/packages.py
+++ b/config/shared/packages.py
@@ -1,0 +1,13 @@
+import pathlib
+
+
+def list_packages(path: pathlib.Path) -> list:
+    """List the packages in ``path``.
+
+    ``path`` must point to a packages.txt file.
+    """
+    return [
+        p
+        for p in path.read_text().split('\n')
+        if p and not p.startswith('#')
+    ]

--- a/config/shared/path.py
+++ b/config/shared/path.py
@@ -1,5 +1,7 @@
+import argparse
 import contextlib
 import os
+import pathlib
 
 
 @contextlib.contextmanager
@@ -14,3 +16,22 @@ def change_dir(path):
         yield cwd
     finally:
         os.chdir(cwd)
+
+
+def path_factory(parameter_name, *, has_extension=None, is_dir=False):
+    """Return factory creating pathlib.Path object if requirements are matched.
+
+    The factory raises an exception otherwise.
+    """
+    def factory(str):
+        path = pathlib.Path(str)
+        if not path.exists():
+            raise argparse.ArgumentTypeError(f'{str!r} does not exist!')
+        if has_extension is not None and path.suffix != has_extension:
+            raise argparse.ArgumentTypeError(
+                f'The required extension is {has_extension!r}'
+                f' not {path.suffix!r}.')
+        if is_dir and not path.is_dir():
+            raise argparse.ArgumentTypeError('has to point to a directory!')
+        return path
+    return factory


### PR DESCRIPTION
Fixes #88.

I started to use the script but we have to update some of our repositories to get the ability to trigger a workflow manually. (This is already in the the default configuration of `meta/config`, but some repositories where migrated before.)

Open issues:

- [x] use `-R` option instead of cloning the repositories
- [x] if activating fails give the option to clone the repository (so it can easily be updated to the current version of `meta/config`)