### PR TITLE
Sphinx 4 got compatible with repoze.sphinx.autointerface again.

### DIFF
--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -212,8 +212,6 @@ jobs:
           pip install -U wheel
           pip install -U coverage
           pip install -U  "`ls dist/%(package_name)s-*.whl`[docs]"
-          # Until repoze.sphinx.autointerface supports Sphinx 4.x we cannot use it:
-          pip install -U "Sphinx < 4"
       - name: Build docs
         env:
           ZOPE_INTERFACE_STRICT_IRO: 1

--- a/config/default/tox-docs.j2
+++ b/config/default/tox-docs.j2
@@ -3,8 +3,6 @@
 [testenv:docs]
 basepython = python3
 skip_install = false
-# Until repoze.sphinx.autointerface supports Sphinx 4.x we cannot use it:
-deps = Sphinx < 4
 {% if not with_sphinx_doctests %}
 extras =
     docs

--- a/config/default/tox-testenv.j2
+++ b/config/default/tox-testenv.j2
@@ -5,10 +5,6 @@ deps =
   {% for line in testenv_deps %}
     %(line)s
   {% endfor %}
-{% if with_sphinx_doctests %}
-    # Until repoze.sphinx.autointerface supports Sphinx 4.x we cannot use it:
-    Sphinx < 4
-{% endif %}
 {% if testenv_setenv %}
 setenv =
   {% for line in testenv_setenv %}

--- a/config/pure-python/tox.ini.j2
+++ b/config/pure-python/tox.ini.j2
@@ -11,10 +11,6 @@ allowlist_externals =
 deps =
     coverage
     coverage-python-version
-{% if with_sphinx_doctests %}
-    # Until repoze.sphinx.autointerface supports Sphinx 4.x we cannot use it:
-    Sphinx < 4
-{% endif %}
 {% for line in testenv_deps %}
     %(line)s
 {% endfor %}


### PR DESCRIPTION
Problem shifted to Sphinx 5.

Used for https://github.com/zopefoundation/zope.schema/pull/109