### PR TITLE
Prevent faulty compiled wheel.

### DIFF
--- a/config/c-code/tests-strategy.j2
+++ b/config/c-code/tests-strategy.j2
@@ -30,7 +30,7 @@
 {% endif %}
 {% if with_pypy %}
           - os: macos-latest
-            python-version: "pypy-3.6"
+            python-version: "pypy-3.7"
 {% endif %}
 {% if with_legacy_python %}
           - os: macos-latest

--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -125,7 +125,7 @@ jobs:
         # We cannot 'uses: pypa/gh-action-pypi-publish@v1.4.1' because
         # that's apparently a container action, and those don't run on
         # the Mac.
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && startsWith(runner.os, 'Mac')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && startsWith(runner.os, 'Mac') && !startsWith(matrix.python-version, 'pypy')
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |


### PR DESCRIPTION
A PyPy never should publish a wheel on PyPI as it cannot be used elsewhere and is not tagged as PyPy only.

Additionally restored that PyPy3 does not run on MacOS. (The version was updated from 3.6 to 3.7 but not the exclude.)

Fixes #128.