### PR TITLE
Run Sphinx doctests only in GHA if the run in tox.

### DIFF
--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -217,7 +217,9 @@ jobs:
           ZOPE_INTERFACE_STRICT_IRO: 1
         run: |
           sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
+  {%- if with_sphinx_doctests %}
           sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest
+  {% endif %}
 {% endif %}
 
   lint:

--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -217,7 +217,7 @@ jobs:
           ZOPE_INTERFACE_STRICT_IRO: 1
         run: |
           sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
-  {%- if with_sphinx_doctests %}
+  {% if with_sphinx_doctests %}
           sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest
   {% endif %}
 {% endif %}

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -346,6 +346,7 @@ copy_with_meta(
     services=gha_services,
     steps_before_checkout=gha_steps_before_checkout,
     with_docs=with_docs,
+    with_sphinx_doctests=with_sphinx_doctests,
     with_legacy_python=with_legacy_python,
     with_future_python=with_future_python,
     with_pypy=with_pypy,


### PR DESCRIPTION
This change is only necessary for the c-code template.
The other ones already use tox in GHA.

Needed for https://github.com/zopefoundation/zope.container/pull/43