### PR TITLE
Do not publish future versions

### DIFF
--- a/config/c-code/tests-strategy.j2
+++ b/config/c-code/tests-strategy.j2
@@ -18,7 +18,7 @@
           - "3.9"
           - "3.10"
 {% if with_future_python %}
-          - "3.11.0-alpha.4"
+          - "%(future_python_version)s"
 {% endif %}
         os: [ubuntu-20.04, macos-latest]
 {% if with_pypy or with_legacy_python or gha_additional_exclude %}

--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -152,7 +152,13 @@ jobs:
       - name: Install %(package_name)s
         run: |
           pip install -U wheel setuptools
+{% if with_future_python %}
+          # coverage has a wheel on PyPI for a future python version which is
+          # not ABI compatible with the current one, so build it from sdist:
           pip install -U --no-binary :all: coverage
+{% else %}
+          pip install -U coverage
+{% endif %}
           pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
           # Unzip into src/ so that testrunner can find the .so files
           # when we ask it to load tests from that directory. This

--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -129,7 +129,7 @@ jobs:
           && startsWith(runner.os, 'Mac')
           && !startsWith(matrix.python-version, 'pypy')
 {% if with_future_python %}
-          && ${{ matrix.python-version != "%(future_python_version)s" }}
+          && ${{ matrix.python-version != '%(future_python_version)s' }}
 {% endif %}
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
@@ -305,7 +305,7 @@ jobs:
           github.event_name == 'push'
           && startsWith(github.ref, 'refs/tags')
 {% if with_future_python %}
-          && ${{ matrix.python-version != "%(future_python_version)s" }}
+          && ${{ matrix.python-version != '%(future_python_version)s' }}
 {% endif %}
         with:
           user: __token__

--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -130,6 +130,9 @@ jobs:
           && startsWith(github.ref, 'refs/tags')
           && startsWith(runner.os, 'Mac')
           && !startsWith(matrix.python-version, 'pypy')
+{% if with_future_python %}
+          && ${{ matrix.python-version != "%(future_python_version)s" }}
+{% endif %}
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
@@ -303,6 +306,9 @@ jobs:
         if: >
           github.event_name == 'push'
           && startsWith(github.ref, 'refs/tags')
+{% if with_future_python %}
+          && ${{ matrix.python-version != "%(future_python_version)s" }}
+{% endif %}
         with:
           user: __token__
           password: ${{ secrets.TWINE_PASSWORD }}

--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -99,7 +99,6 @@ jobs:
         run: |
           pip install -U pip
           pip install -U setuptools wheel twine cffi
-          pip install -U coveralls coverage
 
       - name: Build %(package_name)s
         run: |
@@ -108,7 +107,6 @@ jobs:
           python setup.py build_ext -i
           python setup.py bdist_wheel
           # Also install it, so that we get dependencies in the (pip) cache.
-          pip install -U coverage
           pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
           pip install .[test]
 
@@ -154,7 +152,7 @@ jobs:
       - name: Install %(package_name)s
         run: |
           pip install -U wheel setuptools
-          pip install -U coverage
+          pip install -U --no-binary :all: coverage
           pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
           # Unzip into src/ so that testrunner can find the .so files
           # when we ask it to load tests from that directory. This

--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -129,7 +129,7 @@ jobs:
           && startsWith(runner.os, 'Mac')
           && !startsWith(matrix.python-version, 'pypy')
 {% if with_future_python %}
-          && ${{ matrix.python-version != '%(future_python_version)s' }}
+          && !startsWith(matrix.python-version, '%(future_python_version)s')
 {% endif %}
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
@@ -305,7 +305,7 @@ jobs:
           github.event_name == 'push'
           && startsWith(github.ref, 'refs/tags')
 {% if with_future_python %}
-          && ${{ matrix.python-version != '%(future_python_version)s' }}
+          && !startsWith(matrix.python-version, '%(future_python_version)s')
 {% endif %}
         with:
           user: __token__

--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -304,9 +304,6 @@ jobs:
         if: >
           github.event_name == 'push'
           && startsWith(github.ref, 'refs/tags')
-{% if with_future_python %}
-          && !startsWith(matrix.python-version, '%(future_python_version)s')
-{% endif %}
         with:
           user: __token__
           password: ${{ secrets.TWINE_PASSWORD }}

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -14,6 +14,7 @@ import toml
 META_HINT = """\
 # Generated from:
 # https://github.com/zopefoundation/meta/tree/master/config/{config_type}"""
+FUTUTRE_PYTHON_VERSION = "3.11.0-alpha.4"
 
 
 def copy_with_meta(template_name, destination, config_type, **kw):
@@ -352,6 +353,7 @@ copy_with_meta(
     with_sphinx_doctests=with_sphinx_doctests,
     with_legacy_python=with_legacy_python,
     with_future_python=with_future_python,
+    future_python_version=FUTUTRE_PYTHON_VERSION,
     with_pypy=with_pypy,
     with_windows=with_windows,
 )

--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -38,7 +38,7 @@ jobs:
         - ["3.9",   "py39"]
         - ["3.10",  "py310"]
 {% if with_future_python %}
-        - ["3.11.0-alpha.4",  "py311"]
+        - ["%(future_python_version)s",  "py311"]
 {% endif %}
 {% if with_pypy and with_legacy_python %}
         - ["pypy2", "pypy"]


### PR DESCRIPTION
Their ABI might not be stable, yet and not compatible across the alpha versions.

Use non-binary coverage version.
They published a wheel not compatible with the current alpha release.
Remove installing coverage in places where it is not needed.