### PR TITLE
Add CONTRIBUTING.md to the root of the target repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing to zopefoundation projects
+
+The projects under the zopefoundation GitHub organization are open source and
+welcome contributions in different forms:
+
+* bug reports
+* code improvements and bug fixes
+* documentation improvements
+* pull request reviews
+
+For any changes in the repository besides trivial typo fixes you are required
+to sign the contributor agreement. See
+https://www.zope.dev/developer/becoming-a-committer.html for details.
+
+Please visit our [Developer
+Guidelines](https://www.zope.dev/developer/guidelines.html) if you'd like to
+contribute code changes and our [guidelines for reporting
+bugs](https://www.zope.dev/developer/reporting-bugs.html) if you want to file a
+bug report.

--- a/config/README.rst
+++ b/config/README.rst
@@ -35,6 +35,9 @@ packages:
     ``tox.ini`` to be able to pin the installed dependency versions the same
     way ``buildout.cfg`` does it.
 
+* groktoolkit
+
+  - Configuration currently only used for the groktoolkit repository.
 
 Contents
 --------

--- a/config/README.rst
+++ b/config/README.rst
@@ -47,6 +47,11 @@ Each directory contains the following files if they differ from the default
   - This file lists the packages which use the configuration in the
     directory.
 
+* CONTRIBUTING.md
+
+  - This file is copied as is. It allows developers to easily find our
+    contributing guidelines in the root of the repository.
+
 * editorconfig
 
   - This file is copied to `.editorconfig` and allows developers to have a

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -244,6 +244,7 @@ copy_with_meta(
 )
 copy_with_meta('editorconfig', path / '.editorconfig', config_type)
 copy_with_meta('gitignore', path / '.gitignore', config_type)
+copy_with_meta('CONTRIBUTING.md', path / 'CONTRIBUTING.md', config_type)
 workflows = path / '.github' / 'workflows'
 workflows.mkdir(parents=True, exist_ok=True)
 
@@ -440,7 +441,7 @@ with change_dir(path) as cwd:
         abort(1)
     if args.commit:
         call('git', 'add',
-             'setup.cfg', 'tox.ini', '.gitignore',
+             'setup.cfg', 'tox.ini', '.gitignore', 'CONTRIBUTING.md',
              '.github/workflows/tests.yml', 'MANIFEST.in', '.editorconfig',
              '.meta.toml')
         if args.commit_msg:

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -14,10 +14,16 @@ import toml
 META_HINT = """\
 # Generated from:
 # https://github.com/zopefoundation/meta/tree/master/config/{config_type}"""
+META_HINT_MARKDOWN = """\
+<!--
+Generated from:
+https://github.com/zopefoundation/meta/tree/master/config/{config_type}
+--> """
 FUTUTRE_PYTHON_VERSION = "3.11.0-alpha.4"
 
 
-def copy_with_meta(template_name, destination, config_type, **kw):
+def copy_with_meta(
+        template_name, destination, config_type, meta_hint=META_HINT, **kw):
     """Copy the source file to destination and a hint of origin.
 
     If kwargs are given they are used as template arguments.
@@ -25,7 +31,7 @@ def copy_with_meta(template_name, destination, config_type, **kw):
     with open(destination, 'w') as f_:
         template = jinja_env.get_template(template_name)
         rendered = template.render(config_type=config_type, **kw)
-        meta_hint = META_HINT.format(config_type=config_type)
+        meta_hint = meta_hint.format(config_type=config_type)
         if rendered.startswith('#!'):
             she_bang, _, body = rendered.partition('\n')
             content = '\n'.join([she_bang, meta_hint, body])
@@ -119,6 +125,7 @@ parser.add_argument(
         'c-code',
         'pure-python',
         'zope-product',
+        'groktoolkit',
     ],
     default=None,
     dest='type',
@@ -244,7 +251,9 @@ copy_with_meta(
 )
 copy_with_meta('editorconfig', path / '.editorconfig', config_type)
 copy_with_meta('gitignore', path / '.gitignore', config_type)
-copy_with_meta('CONTRIBUTING.md', path / 'CONTRIBUTING.md', config_type)
+copy_with_meta(
+    'CONTRIBUTING.md', path / 'CONTRIBUTING.md', config_type,
+    meta_hint=META_HINT_MARKDOWN)
 workflows = path / '.github' / 'workflows'
 workflows.mkdir(parents=True, exist_ok=True)
 

--- a/config/default/CONTRIBUTING.md
+++ b/config/default/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing to zopefoundation projects
+
+The projects under the zopefoundation GitHub organization are open source and
+welcome contributions in different forms:
+
+* bug reports
+* code improvements and bug fixes
+* documentation improvements
+* pull request reviews
+
+For any changes in the repository besides trivial typo fixes you are required
+to sign the contributor agreement. See
+https://www.zope.dev/developer/becoming-a-committer.html for details.
+
+Please visit our [Developer
+Guidelines](https://www.zope.dev/developer/guidelines.html) if you'd like to
+contribute code changes and our [guidelines for reporting
+bugs](https://www.zope.dev/developer/reporting-bugs.html) if you want to file a
+bug report.

--- a/config/default/MANIFEST.in.j2
+++ b/config/default/MANIFEST.in.j2
@@ -1,3 +1,4 @@
+include *.md
 include *.rst
 include *.txt
 include buildout.cfg

--- a/config/pure-python/packages.txt
+++ b/config/pure-python/packages.txt
@@ -163,3 +163,4 @@ z3c.ptcompat
 z3c.pt
 zope.componentvocabulary
 zope.testbrowser
+zope.copypastemove


### PR DESCRIPTION
The file is a raw copy of in https://github.com/zopefoundation/.github/blob/master/CONTRIBUTING.md
which is not visible enough: It seems only to be referenced in a notice
on the right hand side when creating the first new PR.

See https://github.com/zopefoundation/zodbpickle/pull/64#issuecomment-1026927634 as an example missing the `CONTRIBUTING.md` file.

See https://github.com/zopefoundation/ExtensionClass/pull/41 which was created using this PR.