### PR TITLE
Fix CONTRIBUTING.md and PyPy3 usage:

### DIFF
--- a/config/config-package.py
+++ b/config/config-package.py
@@ -254,6 +254,10 @@ copy_with_meta('gitignore', path / '.gitignore', config_type)
 copy_with_meta(
     'CONTRIBUTING.md', path / 'CONTRIBUTING.md', config_type,
     meta_hint=META_HINT_MARKDOWN)
+with change_dir(path):
+    # We have to add it here otherwise the linter complains that it is not
+    # added.
+    call('git', 'add', 'CONTRIBUTING.md')
 workflows = path / '.github' / 'workflows'
 workflows.mkdir(parents=True, exist_ok=True)
 
@@ -450,7 +454,7 @@ with change_dir(path) as cwd:
         abort(1)
     if args.commit:
         call('git', 'add',
-             'setup.cfg', 'tox.ini', '.gitignore', 'CONTRIBUTING.md',
+             'setup.cfg', 'tox.ini', '.gitignore',
              '.github/workflows/tests.yml', 'MANIFEST.in', '.editorconfig',
              '.meta.toml')
         if args.commit_msg:

--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -44,7 +44,7 @@ jobs:
         - ["pypy2", "pypy"]
 {% endif %}
 {% if with_pypy %}
-        - ["pypy3", "pypy3"]
+        - ["pypy-3.7", "pypy3"]
 {% endif %}
 {% if with_docs %}
         - ["3.9",   "docs"]


### PR DESCRIPTION
* If CONTRIBUTING.md is not added before the lint tox environment runs it complains that there is a file which is not under version control.
* `pypy3` defaults to `pypy-3.6` which no longer seems to be installed on GHA Windows machines.

Needed for https://github.com/zopefoundation/zope.testrunner/pull/128