### PR TITLE
Allow [tox] -> coverage-command to be a list.

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -241,7 +241,9 @@ updated. Example:
         "    DISPLAY",
         ]
     coverage-basepython = "python3.9"
-    coverage-command = "coverage run {envbindir}/test_with_gs []"
+    coverage-command = [
+        "coverage run {envbindir}/test_with_gs []"
+        ]
     coverage-setenv = [
         "COVERAGE_HOME={toxinidir}",
         ]
@@ -444,7 +446,7 @@ coverage-command
   This option replaces the coverage call in the section ``[testenv:coverage]``
   in ``tox.ini``. *Caution:* only the actual call to collect the coverage data
   is replaced. The calls to create the reporting are not changed. This option
-  has to be a string. If it is not set or empty the default is used.
+  has to be a list or a string. If it is not set or empty the default is used.
 
 coverage-setenv
   This option defines the contents for the option ``setenv`` in the section

--- a/config/buildout-recipe/tox.ini.j2
+++ b/config/buildout-recipe/tox.ini.j2
@@ -26,7 +26,9 @@ commands =
     mkdir -p {toxinidir}/parts/htmlcov
     coverage erase
 {% if coverage_command %}
-    %(coverage_command)s
+  {% for line in coverage_command %}
+    %(line)s
+  {% endfor %}
 {% else %}
     coverage run -m zope.testrunner --test-path=src {posargs:-vc}
 {% endif %}

--- a/config/c-code/packages.txt
+++ b/config/c-code/packages.txt
@@ -13,3 +13,5 @@ Persistence
 zope.security
 zope.container
 BTrees
+persistent
+AccessControl

--- a/config/c-code/tox.ini.j2
+++ b/config/c-code/tox.ini.j2
@@ -51,7 +51,9 @@ setenv =
 commands =
     mkdir -p {toxinidir}/parts/htmlcov
 {% if coverage_command %}
-    %(coverage_command)s
+  {% for line in coverage_command %}
+    %(line)s
+  {% endfor %}
 {% else %}
     coverage run -m zope.testrunner --test-path=src {posargs:-vc}
 {% endif %}

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -302,7 +302,9 @@ testenv_commands_pre = meta_cfg['tox'].get('testenv-commands-pre', [])
 testenv_commands = meta_cfg['tox'].get('testenv-commands', [])
 testenv_setenv = meta_cfg['tox'].get('testenv-setenv', [])
 coverage_basepython = meta_cfg['tox'].get('coverage-basepython', 'python3')
-coverage_command = meta_cfg['tox'].get('coverage-command', '')
+coverage_command = meta_cfg['tox'].get('coverage-command', [])
+if isinstance(coverage_command, str):
+    coverage_command = [coverage_command]
 coverage_additional = meta_cfg['tox'].get('coverage-additional', [])
 testenv_deps = meta_cfg['tox'].get('testenv-deps', [])
 coverage_setenv = meta_cfg['tox'].get('coverage-setenv', [])

--- a/config/pure-python/tox.ini.j2
+++ b/config/pure-python/tox.ini.j2
@@ -23,7 +23,9 @@ setenv =
 commands =
     mkdir -p {toxinidir}/parts/htmlcov
 {% if coverage_command %}
-    %(coverage_command)s
+  {% for line in coverage_command %}
+    %(line)s
+  {% endfor %}
 {% else %}
     coverage run -m zope.testrunner --test-path=src {posargs:-vc}
 {% endif %}

--- a/config/zope-product/tox.ini.j2
+++ b/config/zope-product/tox.ini.j2
@@ -94,7 +94,9 @@ deps =
 commands =
     mkdir -p {toxinidir}/parts/htmlcov
 {% if coverage_command %}
-    %(coverage_command)s
+  {% for line in coverage_command %}
+    %(line)s
+  {% endfor %}
 {% else %}
     coverage run {envbindir}/test {posargs:-cv}
 {% endif %}


### PR DESCRIPTION
This is needed for https://github.com/zopefoundation/persistent/pull/169.