### PR TITLE
Add ability to configure which tests are run on aarch64.

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -341,6 +341,12 @@ updated. Example:
     manylinux-install-setup = [
         "export CFLAGS=\"-pipe\"",
         ]
+    manylinux-aarch64-tests = [
+        "cd /io/",
+        "\"${PYBIN}/pip\" install tox",
+        "\"${PYBIN}/tox\" -e py",
+        "cd ..",
+    ]
 
 
 Meta Options
@@ -618,6 +624,10 @@ manylinux-install-setup
   Additional setup steps necessary in ``manylinux-install.sh``. This option has
   to be a list of strings and defaults to an empty list.
 
+manylinux-aarch64-tests
+  Replacement for the tests against the aarch64 architecture. This option has
+  to be a list of strings and defaults to testing using ``tox`` against all
+  supported Python versions, which could be too slow for some packages.
 
 Hints
 -----

--- a/config/c-code/manylinux-install.sh.j2
+++ b/config/c-code/manylinux-install.sh.j2
@@ -45,10 +45,9 @@ for PYBIN in /opt/python/*/bin; do
         "${PYBIN}/pip" install -e /io/
         "${PYBIN}/pip" wheel /io/ -w wheelhouse/
         if [ `uname -m` == 'aarch64' ]; then
-         cd /io/
-         "${PYBIN}/pip" install tox
-         "${PYBIN}/tox" -e py
-         cd ..
+{% for line in aarch64_tests %}
+          %(line)s
+{% endfor %}
         fi
         rm -rf /io/build /io/*.egg-info
     fi

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -278,6 +278,13 @@ elif (path / '.coveragerc').exists():
 
 manylinux_install_setup = meta_cfg['c-code'].get(
     'manylinux-install-setup', [])
+manylinux_aarch64_tests = meta_cfg['c-code'].get(
+    'manylinux-aarch64-tests', [
+        'cd /io/',
+        '"${PYBIN}/pip" install tox',
+        '"${PYBIN}/tox" -e py',
+        'cd ..',
+    ])
 if (config_type_path / 'manylinux.sh').exists():
     copy_with_meta('manylinux.sh', path / '.manylinux.sh', config_type)
     (path / '.manylinux.sh').chmod(0o755)
@@ -285,6 +292,7 @@ if (config_type_path / 'manylinux.sh').exists():
         'manylinux-install.sh.j2', path / '.manylinux-install.sh', config_type,
         package_name=path.name,
         setup=manylinux_install_setup,
+        aarch64_tests=manylinux_aarch64_tests,
         with_legacy_python=with_legacy_python,
         with_future_python=with_future_python,
     )


### PR DESCRIPTION
This is needed for https://github.com/zopefoundation/BTrees/pull/178