### PR TITLE
Update the zope-product template to zc.buildout 3.x.

### DIFF
--- a/config/zope-product/tox.ini.j2
+++ b/config/zope-product/tox.ini.j2
@@ -3,10 +3,12 @@
 
 [testenv]
 skip_install = true
-# We need to pin setuptools until we have zc.buildout 3.0.
+# We need to pin setuptools < 60 until zc.buildout 3.x supports it.
+# We need to pin pip < 22 because Zope version.cfg does the same to support Python 3.6.
 deps =
-    setuptools < 52
-    zc.buildout
+    setuptools < 60
+    zc.buildout==3.0.0rc2
+    pip < 22
 {% for line in testenv_deps %}
     %(line)s
 {% endfor %}

--- a/config/zope-product/tox.ini.j2
+++ b/config/zope-product/tox.ini.j2
@@ -4,11 +4,9 @@
 [testenv]
 skip_install = true
 # We need to pin setuptools < 60 until zc.buildout 3.x supports it.
-# We need to pin pip < 22 because Zope version.cfg does the same to support Python 3.6.
 deps =
     setuptools < 60
     zc.buildout==3.0.0rc2
-    pip < 22
 {% for line in testenv_deps %}
     %(line)s
 {% endfor %}


### PR DESCRIPTION
This is needed for https://github.com/zopefoundation/Zope/pull/1014.