### PR TITLE
Fix zope-product template:

### DIFF
--- a/config/pure-python/packages.txt
+++ b/config/pure-python/packages.txt
@@ -167,3 +167,5 @@ zope.copypastemove
 zope.principalannotation
 zope.structuredtext
 zope.viewlet
+zope.keyreference
+z3c.template

--- a/config/zope-product/tox.ini.j2
+++ b/config/zope-product/tox.ini.j2
@@ -7,6 +7,7 @@ skip_install = true
 deps =
     setuptools < 60
     zc.buildout==3.0.0rc2
+    wheel > 0.37
 {% for line in testenv_deps %}
     %(line)s
 {% endfor %}
@@ -48,7 +49,7 @@ allowlist_externals =
 commands =
 {% if use_flake8 %}
     isort --check-only --diff {toxinidir}/src {toxinidir}/setup.py
-    - flake8 --format=html {toxinidir}/src {toxinidir}/setup.py%(flake8_additional_sources)s
+    - flake8 {toxinidir}/src {toxinidir}/setup.py%(flake8_additional_sources)s
     flake8 {toxinidir}/src {toxinidir}/setup.py%(flake8_additional_sources)s
 {% endif %}
     check-manifest
@@ -59,8 +60,6 @@ deps =
 {% if use_flake8 %}
     flake8
     isort
-    # helper to generate HTML reports:
-    flake8-html
     # Useful flake8 plugins that are Python and Plone specific:
     flake8-coding
     flake8-debugger


### PR DESCRIPTION
- a current wheel version has to be installed in the first place as otherwise restarting buildout after updating it might fail.
- flake8-html is not compatible with the current version of jinja2 (forcing no flake8 violations make the report obsolete.)

Needed for https://github.com/zopefoundation/Products.MailHost/pull/43