### PR TITLE
Update to zc.buildout 3.0.0rc3.

### DIFF
--- a/config/zope-product/tox.ini.j2
+++ b/config/zope-product/tox.ini.j2
@@ -3,10 +3,8 @@
 
 [testenv]
 skip_install = true
-# We need to pin setuptools < 60 until zc.buildout 3.x supports it.
 deps =
-    setuptools < 60
-    zc.buildout==3.0.0rc2
+    zc.buildout >= 3.0.0rc3
     wheel > 0.37
 {% for line in testenv_deps %}
     %(line)s


### PR DESCRIPTION
This is the first version which supports a current setuptools version.

Used in https://github.com/zopefoundation/Products.CMFCore/pull/122