### PR TITLE
Add isort to linting for type pure-python

### DIFF
--- a/config/default/gitignore
+++ b/config/default/gitignore
@@ -26,4 +26,5 @@ lib64
 log/
 parts/
 pyvenv.cfg
+testing.log
 var/

--- a/config/default/setup.cfg.j2
+++ b/config/default/setup.cfg.j2
@@ -43,7 +43,7 @@ ignore-bad-ideas =
     %(line)s
   {% endfor %}
 {% endif %}
-{% if config_type == 'zope-product' %}
+{% if config_type in ('pure-python', 'zope-product') %}
 
 [isort]
 force_single_line = True

--- a/config/default/tox-lint.j2
+++ b/config/default/tox-lint.j2
@@ -2,16 +2,26 @@
 [testenv:lint]
 basepython = python3
 skip_install = true
-deps =
-{% if use_flake8 %}
-    flake8
-{% endif %}
-    check-manifest
-    check-python-versions >= 0.19.1
-    wheel
 commands =
 {% if use_flake8 %}
+    isort --check-only --diff {toxinidir}/src {toxinidir}/setup.py
     flake8 src setup.py%(flake8_additional_sources)s
 {% endif %}
     check-manifest
     check-python-versions
+deps =
+    check-manifest
+    check-python-versions >= 0.19.1
+    wheel
+{% if use_flake8 %}
+    flake8
+    isort
+
+[testenv:isort-apply]
+basepython = python3
+commands_pre =
+deps =
+    isort
+commands =
+    isort {toxinidir}/src {toxinidir}/setup.py []
+{% endif %}


### PR DESCRIPTION
This PR adds `isort` to the linting configuration for `pure-python`. It also adds a log file to `.gitignore` that is created by `zope.testing.loggingsupport`, which is used by ZEO tests.