### PR TITLE
Allow to use pre-release versions when using future python versions.

### DIFF
--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -168,7 +168,11 @@ jobs:
           # when we ask it to load tests from that directory. This
           # might also save some build time?
           unzip -n dist/%(package_name)s-*whl -d src
+{% if with_future_python %}
+          pip install --pre -U -e .[test]
+{% else %}
           pip install -U -e .[test]
+{% endif %}
       - name: Run tests with C extensions
         if: ${{ !startsWith(matrix.python-version, 'pypy') }}
         run: |

--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -108,7 +108,11 @@ jobs:
           python setup.py bdist_wheel
           # Also install it, so that we get dependencies in the (pip) cache.
           pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
+{% if with_future_python %}
+          pip install --pre .[test]
+{% else %}
           pip install .[test]
+{% endif %}
 
       - name: Check %(package_name)s build
         run: |

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -19,7 +19,7 @@ META_HINT_MARKDOWN = """\
 Generated from:
 https://github.com/zopefoundation/meta/tree/master/config/{config_type}
 --> """
-FUTUTRE_PYTHON_VERSION = "3.11.0-alpha.6"
+FUTURE_PYTHON_VERSION = "3.11.0-alpha.6"
 
 
 def copy_with_meta(
@@ -377,7 +377,7 @@ copy_with_meta(
     with_sphinx_doctests=with_sphinx_doctests,
     with_legacy_python=with_legacy_python,
     with_future_python=with_future_python,
-    future_python_version=FUTUTRE_PYTHON_VERSION,
+    future_python_version=FUTURE_PYTHON_VERSION,
     with_pypy=with_pypy,
     with_windows=with_windows,
 )

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -19,7 +19,7 @@ META_HINT_MARKDOWN = """\
 Generated from:
 https://github.com/zopefoundation/meta/tree/master/config/{config_type}
 --> """
-FUTUTRE_PYTHON_VERSION = "3.11.0-alpha.7"
+FUTUTRE_PYTHON_VERSION = "3.11.0-alpha.6"
 
 
 def copy_with_meta(

--- a/config/default/setup.cfg.j2
+++ b/config/default/setup.cfg.j2
@@ -43,7 +43,6 @@ ignore-bad-ideas =
     %(line)s
   {% endfor %}
 {% endif %}
-{% if config_type in ('pure-python', 'zope-product') %}
 
 [isort]
 force_single_line = True
@@ -58,4 +57,3 @@ known_local_folder = %(isort_known_local_folder)s
 default_section = ZOPE
 line_length = 79
 lines_after_imports = 2
-{% endif %}

--- a/config/default/tox-testenv.j2
+++ b/config/default/tox-testenv.j2
@@ -1,6 +1,9 @@
 
 [testenv]
 usedevelop = true
+{% if with_future_python %}
+pip_pre = true
+{% endif %}
 deps =
   {% for line in testenv_deps %}
     %(line)s


### PR DESCRIPTION
This is needed for https://github.com/zopefoundation/AccessControl/pull/126.

Additionally I had to use `3.11.0-alpha.6` as a7 is not yet on GHA.