### PR TITLE
Do not use `coverage-python-version` together with Python 3.11.

### DIFF
--- a/config/buildout-recipe/coveragerc.j2
+++ b/config/buildout-recipe/coveragerc.j2
@@ -1,6 +1,8 @@
 [run]
 source = %(coverage_run_source)s
+{% if with_legacy_python %}
 plugins = coverage_python_version
+{% endif %}
 branch = true
 parallel = true
 {% for line in run_additional_config %}

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -271,6 +271,7 @@ if (config_type_path / 'coveragerc.j2').exists():
         'coveragerc.j2', path / '.coveragerc', config_type,
         coverage_run_source=coverage_run_source,
         run_additional_config=coverage_run_additional_config,
+        with_legacy_python=with_legacy_python,
     )
     add_coveragerc = True
 elif (path / '.coveragerc').exists():

--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -109,7 +109,11 @@ jobs:
     - name: Coverage
       if: matrix.config[1] == 'coverage'
       run: |
+{% if with_legacy_python %}
         pip install coveralls coverage-python-version
+{% else %}
+        pip install coveralls
+{% endif %}
         coveralls --service=github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/config/default/tox-coverage-config.j2
+++ b/config/default/tox-coverage-config.j2
@@ -1,7 +1,9 @@
 
 [coverage:run]
 branch = True
+{% if with_legacy_python %}
 plugins = coverage_python_version
+{% endif %}
 source = %(coverage_run_source)s
 {% for line in coverage_run_additional_config %}
 %(line)s

--- a/config/pure-python/tox.ini.j2
+++ b/config/pure-python/tox.ini.j2
@@ -10,7 +10,9 @@ allowlist_externals =
     mkdir
 deps =
     coverage
+{% if with_legacy_python %}
     coverage-python-version
+{% endif %}
 {% for line in testenv_deps %}
     %(line)s
 {% endfor %}

--- a/config/zope-product/tox.ini.j2
+++ b/config/zope-product/tox.ini.j2
@@ -87,7 +87,9 @@ setenv =
 deps =
     {[testenv]deps}
     coverage
+{% if with_legacy_python %}
     coverage-python-version
+{% endif %}
 commands =
     mkdir -p {toxinidir}/parts/htmlcov
 {% if coverage_command %}


### PR DESCRIPTION
It does not support coverage 6 which is needed for Python 3.11.