### PR TITLE
Avoid duplicate actions runs in the default GHA template

### DIFF
--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -68,6 +68,7 @@ jobs:
 {% endfor %}
 
     runs-on: ${{ matrix.os }}-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 {% if with_windows %}
     name: ${{ matrix.os }}-${{ matrix.config[1] }}
 {% else %}


### PR DESCRIPTION
Fixes #145 

Sourced (and fixed) from https://wildwolf.name/github-actions-how-to-avoid-running-the-same-workflow-multiple-times/