### PR TITLE
Fix packages which test future Python versions.

### DIFF
--- a/config/default/tox-testenv.j2
+++ b/config/default/tox-testenv.j2
@@ -8,6 +8,10 @@ deps =
   {% for line in testenv_deps %}
     %(line)s
   {% endfor %}
+  {% if with_sphinx_doctests and with_future_python %}
+  # repoze.sphinx.autointerface does not yet support Sphinx >= 5:
+  Sphinx < 5
+  {% endif %}
 {% if testenv_setenv %}
 setenv =
   {% for line in testenv_setenv %}


### PR DESCRIPTION
Some packages testing future Python versions need a RestrictedPython which runs on Python 3.11 so we activated installing pre-released package versions.

Until `repoze.sphinx.autointerface` supports Sphinx 5 we have to use an older version.

Needed by https://github.com/zopefoundation/zope.security/pull/86.