### PR TITLE
Fix building of c-code template for Python 3.10 on MacOS.

### DIFF
--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -112,7 +112,19 @@ jobs:
           pip install -U pip
           pip install -U setuptools wheel twine cffi
 
-      - name: Build %(package_name)s
+{% for kind in ('Python 3.10 on MacOS', 'all other versions') %}
+      - name: Build %(package_name)s (%(kind)s)
+  {% if kind == 'Python 3.10 on MacOS' %}
+        if: >
+          startsWith(runner.os, 'Mac')
+          && startsWith(matrix.python-version, '3.10')
+        env:
+          _PYTHON_HOST_PLATFORM: macosx-11-x86_64
+  {% else %}
+        if: >
+          !startsWith(runner.os, 'Mac')
+          || !startsWith(matrix.python-version, '3.10')
+  {% endif %}
         run: |
           # Next, build the wheel *in place*. This helps ccache, and also lets us cache the configure
           # output (pip install uses a random temporary directory, making this difficult).
@@ -126,6 +138,7 @@ jobs:
           pip install .[test]
 {% endif %}
 
+{% endfor %}
       - name: Check %(package_name)s build
         run: |
           ls -l dist

--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -98,13 +98,13 @@ jobs:
 {% if with_future_python and with_pypy %}
       - name: Install Build Dependencies (PyPy2)
         if: >
-           startsWith(matrix.python-version, 'pypy-2.7')
+          startsWith(matrix.python-version, 'pypy-2.7')
         run: |
           pip install -U pip
           pip install -U setuptools wheel twine "cffi != 1.15.1"
       - name: Install Build Dependencies (other Python versions)
         if: >
-           !startsWith(matrix.python-version, 'pypy-2.7')
+          !startsWith(matrix.python-version, 'pypy-2.7')
 {% else %}
       - name: Install Build Dependencies
 {% endif %}


### PR DESCRIPTION
This is needed for https://github.com/zopefoundation/zope.security/pull/87