### PR TITLE
Fix C-code PyPy2 builds on GHA.

### DIFF
--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -95,7 +95,19 @@ jobs:
     steps:
 {% include 'tests-cache.j2' %}
 
+{% if with_future_python and with_pypy %}
+      - name: Install Build Dependencies (PyPy2)
+        if: >
+           startsWith(matrix.python-version, 'pypy-2.7')
+        run: |
+          pip install -U pip
+          pip install -U setuptools wheel twine "cffi != 1.15.1"
+      - name: Install Build Dependencies (other Python versions)
+        if: >
+           !startsWith(matrix.python-version, 'pypy-2.7')
+{% else %}
       - name: Install Build Dependencies
+{% endif %}
         run: |
           pip install -U pip
           pip install -U setuptools wheel twine cffi


### PR DESCRIPTION
There is already cffi 1.15.0 installed. Uninstalling it fails because a file seems to be missing.
Updating setuptools beforehand did not help, so I am excluding the new cffi version for now and we'll see what happens on the next release.

Used for https://github.com/zopefoundation/Persistence/pull/32
(Needed for all other c-code packages with pypy2 support.)