### PR TITLE
Don't run pull_request and push tests simultaneously

### DIFF
--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -90,6 +90,7 @@ jobs:
     # Sigh. Note that the matrix must be kept in sync
     # with `test`, and `docs` must use a subset.
     runs-on: ${{ matrix.os }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 {% include 'tests-strategy.j2' %}
 
     steps:


### PR DESCRIPTION
This copies a change from the default template to prevent tests for the pull_request event unless the PR is based on an external fork