### PR TITLE
Add support for creating *.mo files during the release process.

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -60,9 +60,10 @@ Each directory contains the following files if they differ from the default
   - This file is copied to `.editorconfig` and allows developers to have a
     common editor configuration experience in all repos.
 
-* gitignore
+* gitignore.j2
 
-  - This file is copied to `.gitignore`.
+  - This file is copied to `.gitignore` and can be appended trough
+    configuration in ``.meta.cfg``.
 
 * MANIFEST.in.j2
 
@@ -346,7 +347,18 @@ updated. Example:
         "\"${PYBIN}/pip\" install tox",
         "\"${PYBIN}/tox\" -e py",
         "cd ..",
-    ]
+        ]
+
+    [zest-releaser]
+    options = [
+        "prereleaser.before =",
+        "    zest.pocompile.compile.main",
+        ]
+
+    [git]
+    ignore = [
+        "*.mo",
+        ]
 
 
 Meta Options
@@ -628,6 +640,26 @@ manylinux-aarch64-tests
   Replacement for the tests against the aarch64 architecture. This option has
   to be a list of strings and defaults to testing using ``tox`` against all
   supported Python versions, which could be too slow for some packages.
+
+zest.releaser options
+`````````````````````
+
+The corresponding section is named: ``[zest-releaser]`` (with an ``-`` instead
+of the ``.``).
+
+options
+  (Additional) options used to configure ``zest.releaser``. This option has to
+  be a list of strings and defaults to an empty list.
+
+
+git options
+```````````
+
+The corresponding section is named: ``[git]``.
+
+ignore
+  Additional lines to be added to the ``.gitignore`` file. This option has to
+  be a list of strings and defaults to an empty list.
 
 Hints
 -----

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -237,6 +237,10 @@ for var in (
         # Avoid whitespace at end of line if empty:
         locals()[var] = ' ' + locals()[var]
 
+zest_releaser_options = meta_cfg['zest-releaser'].get('options', [])
+if config_type == 'c-code':
+    zest_releaser_options.append('create-wheel = no')
+
 copy_with_meta(
     'setup.cfg.j2', path / 'setup.cfg', config_type,
     additional_flake8_config=additional_flake8_config,
@@ -248,9 +252,16 @@ copy_with_meta(
     isort_known_local_folder=isort_known_local_folder,
     with_docs=with_docs, with_sphinx_doctests=with_sphinx_doctests,
     with_legacy_python=with_legacy_python,
+    zest_releaser_options=zest_releaser_options,
+)
+
+git_ignore = meta_cfg['git'].get('ignore', [])
+
+copy_with_meta(
+    'gitignore.j2', path / '.gitignore', config_type,
+    ignore=git_ignore,
 )
 copy_with_meta('editorconfig', path / '.editorconfig', config_type)
-copy_with_meta('gitignore', path / '.gitignore', config_type)
 copy_with_meta(
     'CONTRIBUTING.md', path / 'CONTRIBUTING.md', config_type,
     meta_hint=META_HINT_MARKDOWN)

--- a/config/default/gitignore.j2
+++ b/config/default/gitignore.j2
@@ -28,3 +28,6 @@ parts/
 pyvenv.cfg
 testing.log
 var/
+{% for line in ignore %}
+%(line)s
+{% endfor %}

--- a/config/default/setup.cfg.j2
+++ b/config/default/setup.cfg.j2
@@ -4,10 +4,12 @@ universal = 1
 {% else %}
 universal = 0
 {% endif %}
-{% if config_type == 'c-code' %}
+{% if zest_releaser_options %}
 
 [zest.releaser]
-create-wheel = no
+{% for line in zest_releaser_options %}
+%(line)s
+{% endfor %}
 {% endif %}
 
 [flake8]


### PR DESCRIPTION
This needs the ability to add `*.mo` to `.gitignore` and the ability to configure `zest.releaser` to require `zest.pocompile`.

It is used in https://github.com/zopefoundation/zope.app.locales/pull/18.