### PR TITLE
Disable unsafe math optimizations (try 2)

### DIFF
--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -60,8 +60,8 @@ env:
   PIP_NO_PYTHON_VERSION_WARNING: 1
   PIP_NO_WARN_SCRIPT_LOCATION: 1
 
-  CFLAGS: -Ofast -pipe -fno-unsafe-math-optimizations
-  CXXFLAGS: -Ofast -pipe -fno-unsafe-math-optimizations
+  CFLAGS: -O3 -pipe
+  CXXFLAGS: -O3 -pipe
   # Uploading built wheels for releases.
   # TWINE_PASSWORD is encrypted and stored directly in the
   # github repo settings.


### PR DESCRIPTION
As @Nephirus wrote on https://github.com/zopefoundation/BTrees/pull/179:

> Current binary wheels use -Ofast optimization option, which (apart from other things) enables flush-to-zero (FTZ) behavior for IEEE-754 subnormals. Unfortunately, FTZ is a global CPU flag, so it affect other running code.

Unfortunately -fno-unsafe-math-optimizations does not override -Ofast, so we have to stop using -Ofast instead.