### PR TITLE
Fix path to ``test`` script on Windows

### DIFF
--- a/config/zope-product/tox.ini.j2
+++ b/config/zope-product/tox.ini.j2
@@ -30,7 +30,7 @@ commands =
     %(line)s
   {% endfor %}
 {% else %}
-    {envbindir}/test {posargs:-cv}
+    {envdir}/bin/test {posargs:-cv}
 {% endif %}
 {% for line in testenv_additional %}
 %(line)s
@@ -97,7 +97,7 @@ commands =
     %(line)s
   {% endfor %}
 {% else %}
-    coverage run {envbindir}/test {posargs:-cv}
+    coverage run {envdir}/bin/test {posargs:-cv}
 {% endif %}
     coverage html
     coverage report -m --fail-under=%(fail_under)s


### PR DESCRIPTION
Fixes #56 

This change creates paths to the `test` script using `{envdir}/bin` explicitly instead of `{envbindir}`, which breaks those paths on Windows.

See https://github.com/zopefoundation/DateTime/pull/40/files for a place where I had to fix those paths manually because Windows tests broke.