### PR TITLE
Skip manylinux pr the same way it is done for the other jobs.

### DIFF
--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -308,6 +308,7 @@ jobs:
 
   manylinux:
     runs-on: ubuntu-20.04
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     # We use a regular Python matrix entry to share as much code as possible.
     strategy:
       matrix:


### PR DESCRIPTION
Tested in https://github.com/zopefoundation/AccessControl/pull/134