### PR TITLE
Fix GHA deprecation warning.

### DIFF
--- a/config/c-code/tests-cache.j2
+++ b/config/c-code/tests-cache.j2
@@ -13,7 +13,7 @@
       - name: Get pip cache dir
         id: pip-cache
         run: |
-          echo "name=dir=$(pip cache dir)" >>$GITHUB_OUTPUT
+          echo "dir=$(pip cache dir)" >>$GITHUB_OUTPUT
 
       - name: pip cache
         uses: actions/cache@v2

--- a/config/c-code/tests-cache.j2
+++ b/config/c-code/tests-cache.j2
@@ -13,7 +13,7 @@
       - name: Get pip cache dir
         id: pip-cache
         run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+          echo "name=dir=$(pip cache dir)" >>$GITHUB_OUTPUT
 
       - name: pip cache
         uses: actions/cache@v2


### PR DESCRIPTION
Source https://hynek.me/til/set-output-deprecation-github-actions/

Tested in https://github.com/zopefoundation/Persistence/pull/34