### PR TITLE
Add support for Python 3.11 final.

### DIFF
--- a/config/config-package.py
+++ b/config/config-package.py
@@ -19,7 +19,7 @@ META_HINT_MARKDOWN = """\
 Generated from:
 https://github.com/zopefoundation/meta/tree/master/config/{config_type}
 --> """
-FUTURE_PYTHON_VERSION = "3.11.0-rc.2"
+FUTURE_PYTHON_VERSION = "3.11"
 
 
 def copy_with_meta(

--- a/config/default/appveyor.yml.j2
+++ b/config/default/appveyor.yml.j2
@@ -28,8 +28,8 @@ environment:
 {% if with_future_python %}
     # `multibuild` cannot install non-final versions as they are not on
     # ftp.python.org, so we skip Python 3.11 until its final release:
-    # - python: 311
-    # - python: 311-x64
+    - python: 311
+    - python: 311-x64
 {% endif %}
 {% for line in additional_matrix %}
     %(line)s


### PR DESCRIPTION
The next step would be to declare 3.11 as generally supported version instead of being a future version but there is no 3.12 release on GHA, yet.

Used for https://github.com/zopefoundation/ExtensionClass/pull/56