### PR TITLE
Declare Python 3.11 als officially supported.

### DIFF
--- a/config/c-code/manylinux-install.sh.j2
+++ b/config/c-code/manylinux-install.sh.j2
@@ -34,13 +34,14 @@ tox_env_map() {
         *"cp35"*) echo 'py35';;
 {% endif %}
 {% if with_future_python %}
-        *"cp311"*) echo 'py311';;
+        *"cp312"*) echo 'py312';;
 {% endif %}
         *"cp36"*) echo 'py36';;
         *"cp37"*) echo 'py37';;
         *"cp38"*) echo 'py38';;
         *"cp39"*) echo 'py39';;
         *"cp310"*) echo 'py310';;
+        *"cp311"*) echo 'py311';;
         *) echo 'py';;
     esac
 }
@@ -53,15 +54,16 @@ for PYBIN in /opt/python/*/bin; do
        [[ "${PYBIN}" == *"cp35"* ]] || \
 {% endif %}
 {% if with_future_python %}
-       [[ "${PYBIN}" == *"cp311"* ]] || \
+       [[ "${PYBIN}" == *"cp312"* ]] || \
 {% endif %}
+       [[ "${PYBIN}" == *"cp311"* ]] || \
        [[ "${PYBIN}" == *"cp36"* ]] || \
        [[ "${PYBIN}" == *"cp37"* ]] || \
        [[ "${PYBIN}" == *"cp38"* ]] || \
        [[ "${PYBIN}" == *"cp39"* ]] || \
        [[ "${PYBIN}" == *"cp310"* ]] ; then
 {% if with_future_python %}
-        if [[ "${PYBIN}" == *"cp311"* ]] ; then
+        if [[ "${PYBIN}" == *"cp312"* ]] ; then
             "${PYBIN}/pip" install --pre -e /io/
             "${PYBIN}/pip" wheel /io/ --pre -w wheelhouse/
         else

--- a/config/c-code/tests-strategy.j2
+++ b/config/c-code/tests-strategy.j2
@@ -17,6 +17,7 @@
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
 {% if with_future_python %}
           - "%(future_python_version)s"
 {% endif %}

--- a/config/c-code/tox.ini.j2
+++ b/config/c-code/tox.ini.j2
@@ -15,8 +15,9 @@ envlist =
     py38,py38-pure
     py39,py39-pure
     py310,py310-pure
-{% if with_future_python %}
     py311,py311-pure
+{% if with_future_python %}
+    py312,py312-pure
 {% endif %}
 {% if with_pypy and with_legacy_python %}
     pypy

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -19,7 +19,7 @@ META_HINT_MARKDOWN = """\
 Generated from:
 https://github.com/zopefoundation/meta/tree/master/config/{config_type}
 --> """
-FUTURE_PYTHON_VERSION = "3.11"
+FUTURE_PYTHON_VERSION = "3.12.0-alpha.1"
 
 
 def copy_with_meta(

--- a/config/default/appveyor.yml.j2
+++ b/config/default/appveyor.yml.j2
@@ -25,11 +25,13 @@ environment:
     - python: 39-x64
     - python: 310
     - python: 310-x64
+    - python: 311
+    - python: 311-x64
 {% if with_future_python %}
     # `multibuild` cannot install non-final versions as they are not on
     # ftp.python.org, so we skip Python 3.11 until its final release:
-    - python: 311
-    - python: 311-x64
+    # - python: 312
+    # - python: 312-x64
 {% endif %}
 {% for line in additional_matrix %}
     %(line)s

--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -37,8 +37,9 @@ jobs:
         - ["3.8",   "py38"]
         - ["3.9",   "py39"]
         - ["3.10",  "py310"]
+        - ["3.11",  "py311"]
 {% if with_future_python %}
-        - ["%(future_python_version)s",  "py311"]
+        - ["%(future_python_version)s",  "py312"]
 {% endif %}
 {% if with_pypy and with_legacy_python %}
         - ["pypy-2.7", "pypy"]

--- a/config/default/tox-envlist.j2
+++ b/config/default/tox-envlist.j2
@@ -11,8 +11,9 @@ envlist =
     py38
     py39
     py310
-{% if with_future_python %}
     py311
+{% if with_future_python %}
+    py312
 {% endif %}
 {% if with_pypy and with_legacy_python %}
     pypy

--- a/config/default/tox-testenv.j2
+++ b/config/default/tox-testenv.j2
@@ -2,7 +2,7 @@
 [testenv]
 usedevelop = true
 {% if with_future_python %}
-pip_pre = py311: true
+pip_pre = py312: true
 {% endif %}
 deps =
   {% for line in testenv_deps %}


### PR DESCRIPTION
Make Python 3.12 the new future version.
(Even though the first alpha release is not yet available on GHA.)

Maybe we do not have to merge this PR now, but it is needed for https://github.com/zopefoundation/RestrictedPython/pull/243.