### PR TITLE
Apply Michael's fix for macOS 3.11

### DIFF
--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -125,17 +125,19 @@ jobs:
           pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
           pip install --pre .[test]
 {% endif %}
-{% for kind in ('Python 3.10 on MacOS', 'all other versions') %}
+{% for kind in ('Python 3.10 and 3.11 on MacOS', 'all other versions') %}
       - name: Build %(package_name)s (%(kind)s)
         if: >
-  {% if kind == 'Python 3.10 on MacOS' %}
+  {% if kind == 'Python 3.10 and 3.11 on MacOS' %}
           startsWith(runner.os, 'Mac')
-          && startsWith(matrix.python-version, '3.10')
+          && (startsWith(matrix.python-version, '3.10')
+              || startsWith(matrix.python-version, '3.11'))
         env:
           _PYTHON_HOST_PLATFORM: macosx-11-x86_64
   {% else %}
           !startsWith(runner.os, 'Mac')
-          || !startsWith(matrix.python-version, '3.10')
+          || !(startsWith(matrix.python-version, '3.10')
+               || startsWith(matrix.python-version, '3.11'))
   {% endif %}
         run: |
           # Next, build the wheel *in place*. This helps ccache, and also lets us cache the configure


### PR DESCRIPTION
Taken from https://github.com/zopefoundation/BTrees/pull/186

I have been using this to finish zope.container and zope.security already