### PR TITLE
Drop 32-bit Windows support.

### DIFF
--- a/config/default/appveyor.yml.j2
+++ b/config/default/appveyor.yml.j2
@@ -10,27 +10,18 @@ environment:
 
   matrix:
 {% if with_legacy_python %}
-    - python: 27
     - python: 27-x64
-    - python: 35
     - python: 35-x64
 {% endif %}
-    - python: 36
     - python: 36-x64
-    - python: 37
     - python: 37-x64
-    - python: 38
     - python: 38-x64
-    - python: 39
     - python: 39-x64
-    - python: 310
     - python: 310-x64
-    - python: 311
     - python: 311-x64
 {% if with_future_python %}
     # `multibuild` cannot install non-final versions as they are not on
     # ftp.python.org, so we skip Python 3.11 until its final release:
-    # - python: 312
     # - python: 312-x64
 {% endif %}
 {% for line in additional_matrix %}


### PR DESCRIPTION
Not testing 32-bit on Windows also means, we do no longer create 32-bit Windows wheels.

@dataflake Is this the goal you wanted to achieve with #165?

Tested in https://github.com/zopefoundation/ExtensionClass/pull/57.

Fixes #165.