### PR TITLE
Update actions versions to fix deprecation warnings

### DIFF
--- a/config/c-code/tests-cache.j2
+++ b/config/c-code/tests-cache.j2
@@ -1,7 +1,7 @@
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       ###
@@ -16,7 +16,7 @@
           echo "dir=$(pip cache dir)" >>$GITHUB_OUTPUT
 
       - name: pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: %(cache_key)s

--- a/config/c-code/tests-download.j2
+++ b/config/c-code/tests-download.j2
@@ -1,6 +1,6 @@
 
       - name: Download %(package_name)s wheel
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: %(package_name)s-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/

--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -154,7 +154,7 @@ jobs:
           ls -l dist
           twine check dist/*
       - name: Upload %(package_name)s wheel
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: %(package_name)s-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/*whl
@@ -351,14 +351,14 @@ jobs:
           bash .manylinux.sh
 
       - name: Upload %(package_name)s wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           path: wheelhouse/*whl
           name: manylinux_${{ matrix.image }}_wheels.zip
       - name: Restore pip cache permissions
         run: sudo chown -R $(whoami) ${{ steps.pip-cache.outputs.dir }}
       - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.4.1
+        uses: pypa/gh-action-pypi-publish@release/v1
         if: >
           github.event_name == 'push'
           && startsWith(github.ref, 'refs/tags')

--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -79,13 +79,13 @@ jobs:
 {% for line in steps_before_checkout %}
     %(line)s
 {% endfor %}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.config[0] }}
     - name: Pip cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}


### PR DESCRIPTION
This will get rid of many deprecation warnings about node versions etc.