### PR TITLE
Require at least zc.buildout 3.0.1

### DIFF
--- a/config/zope-product/tox.ini.j2
+++ b/config/zope-product/tox.ini.j2
@@ -4,7 +4,7 @@
 [testenv]
 skip_install = true
 deps =
-    zc.buildout >= 3.0.0rc3
+    zc.buildout >= 3.0.1
     wheel > 0.37
 {% for line in testenv_deps %}
     %(line)s


### PR DESCRIPTION
zc.buildout 3.0.0 was a brown bag release and 3.0.0rc3 doesn't work well with the latest pip/setuptools/etc