### PR TITLE
Add a flag to explicitly add testing on macOS test runners

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -300,7 +300,7 @@ updated. Example:
         ]
     additional-exclude = [
         "- { os: windows, config: [\"pypy-2.7\", \"pypy\"] }",
-        "- { os: macos-latest, config: [\"pypy-2.7\", \"pypy\"] }",
+        "- { os: macos, config: [\"pypy-2.7\", \"pypy\"] }",
         ]
     steps-before-checkout = [
         "- name: \"Set some Postgres settings\"",

--- a/config/README.rst
+++ b/config/README.rst
@@ -155,6 +155,9 @@ The following options are only needed one time as their values re stored in
 --with-appveyor
   Enable running the tests on AppVeyor, too.
 
+--with-macos
+  Enable running the tests on macOS on GitHub Actions.
+
 --with-windows
   Enable running the tests on Windows on GitHub Actions.
 
@@ -204,6 +207,7 @@ updated. Example:
     with-pypy = false
     with-docs = true
     with-sphinx-doctests = false
+    with-macos = false
     with-windows = false
 
     [coverage]
@@ -296,6 +300,7 @@ updated. Example:
         ]
     additional-exclude = [
         "- { os: windows, config: [\"pypy-2.7\", \"pypy\"] }",
+        "- { os: macos-latest, config: [\"pypy-2.7\", \"pypy\"] }",
         ]
     steps-before-checkout = [
         "- name: \"Set some Postgres settings\"",
@@ -379,6 +384,9 @@ Python options
 
 with-appveyor
   Run the tests also on AppVeyor: true/false
+
+with-macos
+  Run the tests also on macOS on GitHub Actions: true/false, default: false
 
 with-windows
   Run the tests also on Windows on GitHub Actions: true/false, default: false

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -75,6 +75,13 @@ parser.add_argument(
     help='Activate running tests on AppVeyor, too, if not already configured'
          ' in .meta.toml.')
 parser.add_argument(
+    '--with-macos',
+    dest='with_macos',
+    action='store_true',
+    default=False,
+    help='Activate running tests on macOS on GitHub Actions, too, if not'
+         ' already configured in .meta.toml.')
+parser.add_argument(
     '--with-windows',
     dest='with_windows',
     action='store_true',
@@ -193,6 +200,9 @@ meta_cfg['meta']['commit-id'] = call(
 with_appveyor = meta_cfg['python'].get(
     'with-appveyor', False) or args.with_appveyor
 meta_cfg['python']['with-appveyor'] = with_appveyor
+with_macos = meta_cfg['python'].get(
+    'with-macos', False) or args.with_macos
+meta_cfg['python']['with-macos'] = with_macos
 with_windows = meta_cfg['python'].get(
     'with-windows', False) or args.with_windows
 meta_cfg['python']['with-windows'] = with_windows
@@ -397,6 +407,7 @@ copy_with_meta(
     with_future_python=with_future_python,
     future_python_version=FUTURE_PYTHON_VERSION,
     with_pypy=with_pypy,
+    with_macos=with_macos,
     with_windows=with_windows,
 )
 

--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -25,6 +25,9 @@ jobs:
 {% if with_windows %}
         - windows
 {% endif %}
+{% if with_macos %}
+        - macos
+{% endif %}
         config:
         # [Python version, tox env]
         - ["3.9",   "lint"]
@@ -64,13 +67,21 @@ jobs:
   {% endif %}
           - { os: windows, config: ["3.9",   "coverage"] }
 {% endif %}
+{% if with_macos %}
+          - { os: macos, config: ["3.9",   "lint"] }
+  {% if with_docs %}
+          - { os: macos, config: ["3.9",   "docs"] }
+  {% endif %}
+          - { os: macos, config: ["3.9",   "coverage"] }
+{% endif %}
+
 {% for line in gha_additional_exclude %}
           %(line)s
 {% endfor %}
 
     runs-on: ${{ matrix.os }}-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-{% if with_windows %}
+{% if with_windows or with_macos %}
     name: ${{ matrix.os }}-${{ matrix.config[1] }}
 {% else %}
     name: ${{ matrix.config[1] }}


### PR DESCRIPTION
This works just like `--with-windows` and it allows us to force testing on macOS with packages where it's important, like Zope itself.