### PR TITLE
Enable building x86_64, arm64 and universal2 wheels on supported macOS Python versions

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -305,6 +305,10 @@ updated. Example:
         "sudo apt-get update && sudo apt-get install -y libxml2-dev libxslt-dev",
         "pip install tox-factor"
         ]
+    additional-build-dependencies = [
+        "cffi",
+        "python-ldap",
+        ]
     test-commands = [
         "tox -f ${{ matrix.config[1] }}",
         ]
@@ -585,6 +589,12 @@ additional-install
   running the tests on GitHub Actions. This option has to be a list of strings.
   For the template ``c-code`` this option is currently used to replace how to
   install the package itself and run tests and coverage.
+
+additional-build-dependencies
+  Additional Python packages to install into the virtual environment before
+  building a package with C extensions. This is used for the ``c-code``
+  template to work around issues on macOS where setuptools attempts to retrieve
+  wheels and convert them to eggs multiple times.
 
 test-commands
   Replacement for the test command in ``tests.yml``.

--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -133,7 +133,9 @@ jobs:
           && (startsWith(matrix.python-version, '3.10')
               || startsWith(matrix.python-version, '3.11'))
         env:
-          _PYTHON_HOST_PLATFORM: macosx-11-x86_64
+          MACOSX_DEPLOYMENT_TARGET: 10.9
+          _PYTHON_HOST_PLATFORM: macosx-10.9-x86_64
+          ARCHFLAGS: -arch x86_64
   {% else %}
           !startsWith(runner.os, 'Mac')
           || !(startsWith(matrix.python-version, '3.10')

--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -182,6 +182,8 @@ jobs:
         if: matrix.python-version == '%(future_python_version)s'
         run: |
           # Install to collect dependencies into the (pip) cache.
+          # Use "--pre" here because dependencies with support for this future
+          # Python release may only be available as pre-releases
           pip install --pre .[test]
 {% endif %}
       - name: Install %(package_name)s and dependencies
@@ -282,6 +284,8 @@ jobs:
           # when we ask it to load tests from that directory. This
           # might also save some build time?
           unzip -n dist/%(package_name)s-*whl -d src
+          # Use "--pre" here because dependencies with support for this future
+          # Python release may only be available as pre-releases
           pip install --pre -U -e .[test]
 {% endif %}
       - name: Install %(package_name)s

--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -123,18 +123,6 @@ jobs:
   {% endfor %}
 {% endif %}
 
-{% if with_future_python %}
-      - name: Build %(package_name)s (%(future_python_version)s)
-        if: ${{ startsWith(matrix.python-version, '%(future_python_version)s') }}
-        run: |
-          # Next, build the wheel *in place*. This helps ccache, and also lets us cache the configure
-          # output (pip install uses a random temporary directory, making this difficult).
-          python setup.py build_ext -i
-          python setup.py bdist_wheel
-          # Also install it, so that we get dependencies in the (pip) cache.
-          pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
-          pip install --pre .[test]
-{% endif %}
 {% for kind in ('macOS x86_64, Python 3.8+',
                 'macOS arm64, Python 3.8+',
                 'all other versions') %}
@@ -175,11 +163,24 @@ jobs:
           # output (pip install uses a random temporary directory, making this difficult).
           python setup.py build_ext -i
           python setup.py bdist_wheel
-          # Also install it, so that we get dependencies in the (pip) cache.
+{% endfor %}
+
+{% if with_future_python %}
+      - name: Install %(package_name)s and dependencies (%(future_python_version)s)
+        if: matrix.python-version == '%(future_python_version)s'
+        run: |
+          # Install to collect dependencies into the (pip) cache.
+          pip install --pre .[test]
+{% endif %}
+      - name: Install %(package_name)s and dependencies
+{% if with_future_python %}
+        if: matrix.python-version != '%(future_python_version)s'
+{% endif %}
+        run: |
+          # Install to collect dependencies into the (pip) cache.
           pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
           pip install .[test]
 
-{% endfor %}
       - name: Check %(package_name)s build
         run: |
           ls -l dist

--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -103,6 +103,11 @@ jobs:
         run: |
           pip install -U pip
           pip install -U setuptools wheel twine "cffi != 1.15.1"
+{% if gha_additional_build_dependencies %}
+  {% for line in gha_additional_build_dependencies %}
+          pip install -U %(line)s
+  {% endfor %}
+{% endif %}
       - name: Install Build Dependencies (other Python versions)
         if: >
           !startsWith(matrix.python-version, 'pypy-2.7')

--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -271,6 +271,7 @@ jobs:
           pip install -U wheel setuptools
           pip install -U coverage
           pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
+          pip install -U 'cffi; platform_python_implementation == "CPython"'
           # Unzip into src/ so that testrunner can find the .so files
           # when we ask it to load tests from that directory. This
           # might also save some build time?

--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -135,21 +135,40 @@ jobs:
           pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
           pip install --pre .[test]
 {% endif %}
-{% for kind in ('Python 3.10 and 3.11 on MacOS', 'all other versions') %}
+{% for kind in ('macOS x86_64, Python 3.8+',
+                'macOS arm64, Python 3.8+',
+                'all other versions') %}
       - name: Build %(package_name)s (%(kind)s)
         if: >
-  {% if kind == 'Python 3.10 and 3.11 on MacOS' %}
+  {% if kind == 'macOS x86_64, Python 3.8+' %}
           startsWith(runner.os, 'Mac')
-          && (startsWith(matrix.python-version, '3.10')
-              || startsWith(matrix.python-version, '3.11'))
+          && !(startsWith(matrix.python-version, 'pypy')
+               || matrix.python-version == '2.7'
+               || matrix.python-version == '3.5'
+               || matrix.python-version == '3.6'
+               || matrix.python-version == '3.7')
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.9
           _PYTHON_HOST_PLATFORM: macosx-10.9-x86_64
           ARCHFLAGS: -arch x86_64
+  {% elif kind == 'macOS arm64, Python 3.8+' %}
+          startsWith(runner.os, 'Mac')
+          && !(startsWith(matrix.python-version, 'pypy')
+               || matrix.python-version == '2.7'
+               || matrix.python-version == '3.5'
+               || matrix.python-version == '3.6'
+               || matrix.python-version == '3.7')
+        env:
+          MACOSX_DEPLOYMENT_TARGET: 11.0
+          _PYTHON_HOST_PLATFORM: macosx-11.0-arm64
+          ARCHFLAGS: -arch arm64
   {% else %}
           !startsWith(runner.os, 'Mac')
-          || !(startsWith(matrix.python-version, '3.10')
-               || startsWith(matrix.python-version, '3.11'))
+          || startsWith(matrix.python-version, 'pypy')
+          || matrix.python-version == '2.7'
+          || matrix.python-version == '3.5'
+          || matrix.python-version == '3.6'
+          || matrix.python-version == '3.7'
   {% endif %}
         run: |
           # Next, build the wheel *in place*. This helps ccache, and also lets us cache the configure
@@ -165,11 +184,39 @@ jobs:
         run: |
           ls -l dist
           twine check dist/*
-      - name: Upload %(package_name)s wheel
+{% for kind in ('macOS x86_64', 'macOS arm64', 'all other platforms') %}
+      - name: Upload %(package_name)s wheel (%(kind)s)
+        if: >
+  {% if kind == 'macOS x86_64' %}
+          startsWith(runner.os, 'Mac')
+  {% elif kind == 'macOS arm64' %}
+          startsWith(runner.os, 'Mac')
+          && !(startsWith(matrix.python-version, 'pypy')
+               || matrix.python-version == '2.7'
+               || matrix.python-version == '3.5'
+               || matrix.python-version == '3.6'
+               || matrix.python-version == '3.7')
+    {% else %}
+          !startsWith(runner.os, 'Mac')
+    {% endif %}
         uses: actions/upload-artifact@v3
         with:
+  {% if kind == 'macOS arm64' %}
+          # The arm64 wheel is uploaded with a different name just so it can be
+          # manually downloaded when desired. The wheel itself *cannot* be tested
+          # on the GHA runner, which uses x86_64 architecture.
+          name: %(package_name)s-${{ runner.os }}-${{ matrix.python-version }}-arm64.whl
+  {% else %}
           name: %(package_name)s-${{ runner.os }}-${{ matrix.python-version }}.whl
+  {% endif %}
+  {% if kind == 'macOS x86_64' %}
+          path: dist/*x86_64.whl
+  {% elif kind == 'macOS arm64' %}
+          path: dist/*arm64.whl
+  {% else %}
           path: dist/*whl
+  {% endif %}
+{% endfor %}
       - name: Publish package to PyPI (mac)
         # We cannot 'uses: pypa/gh-action-pypi-publish@v1.4.1' because
         # that's apparently a container action, and those don't run on

--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -112,6 +112,11 @@ jobs:
         run: |
           pip install -U pip
           pip install -U setuptools wheel twine cffi
+{% if gha_additional_build_dependencies %}
+  {% for line in gha_additional_build_dependencies %}
+          pip install -U %(line)s
+  {% endfor %}
+{% endif %}
 
 {% if with_future_python %}
       - name: Build %(package_name)s (%(future_python_version)s)

--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -125,6 +125,7 @@ jobs:
 
 {% for kind in ('macOS x86_64, Python 3.8+',
                 'macOS arm64, Python 3.8+',
+                'macOS universal2, Python 3.8+',
                 'all other versions') %}
       - name: Build %(package_name)s (%(kind)s)
         if: >
@@ -150,6 +151,17 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: 11.0
           _PYTHON_HOST_PLATFORM: macosx-11.0-arm64
           ARCHFLAGS: -arch arm64
+  {% elif kind == 'macOS universal2, Python 3.8+' %}
+          startsWith(runner.os, 'Mac')
+          && !(startsWith(matrix.python-version, 'pypy')
+               || matrix.python-version == '2.7'
+               || matrix.python-version == '3.5'
+               || matrix.python-version == '3.6'
+               || matrix.python-version == '3.7')
+        env:
+          MACOSX_DEPLOYMENT_TARGET: 10.9
+          _PYTHON_HOST_PLATFORM: macosx-10.9-universal2
+          ARCHFLAGS: -arch arm64 -arch x86_64
   {% else %}
           !startsWith(runner.os, 'Mac')
           || startsWith(matrix.python-version, 'pypy')
@@ -185,12 +197,15 @@ jobs:
         run: |
           ls -l dist
           twine check dist/*
-{% for kind in ('macOS x86_64', 'macOS arm64', 'all other platforms') %}
+{% for kind in ('macOS x86_64',
+                'macOS arm64',
+                'macOS universal2',
+                'all other platforms') %}
       - name: Upload %(package_name)s wheel (%(kind)s)
         if: >
   {% if kind == 'macOS x86_64' %}
           startsWith(runner.os, 'Mac')
-  {% elif kind == 'macOS arm64' %}
+  {% elif kind == 'macOS arm64' or kind == 'macOS universal2' %}
           startsWith(runner.os, 'Mac')
           && !(startsWith(matrix.python-version, 'pypy')
                || matrix.python-version == '2.7'
@@ -207,6 +222,10 @@ jobs:
           # manually downloaded when desired. The wheel itself *cannot* be tested
           # on the GHA runner, which uses x86_64 architecture.
           name: %(package_name)s-${{ runner.os }}-${{ matrix.python-version }}-arm64.whl
+  {% elif kind == 'macOS universal2' %}
+          # The universal2 wheel is uploaded with a different name just so it
+          # can be manually downloaded when desired.
+          name: %(package_name)s-${{ runner.os }}-${{ matrix.python-version }}-universal2.whl
   {% else %}
           name: %(package_name)s-${{ runner.os }}-${{ matrix.python-version }}.whl
   {% endif %}
@@ -214,6 +233,8 @@ jobs:
           path: dist/*x86_64.whl
   {% elif kind == 'macOS arm64' %}
           path: dist/*arm64.whl
+  {% elif kind == 'macOS universal2' %}
+          path: dist/*universal2.whl
   {% else %}
           path: dist/*whl
   {% endif %}

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -380,6 +380,8 @@ gha_steps_before_checkout = meta_cfg['github-actions'].get(
     'steps-before-checkout', [])
 gha_additional_install = meta_cfg['github-actions'].get(
     'additional-install', [])
+gha_additional_build_dependencies = meta_cfg['github-actions'].get(
+    'additional-build-dependencies', [])
 gha_test_commands = meta_cfg['github-actions'].get(
     'test-commands', [])
 copy_with_meta(
@@ -387,6 +389,7 @@ copy_with_meta(
     gha_additional_config=gha_additional_config,
     gha_additional_exclude=gha_additional_exclude,
     gha_additional_install=gha_additional_install,
+    gha_additional_build_dependencies=gha_additional_build_dependencies,
     gha_test_commands=gha_test_commands,
     package_name=path.name,
     services=gha_services,


### PR DESCRIPTION
This change applies the same environment flags used by cibuildwheel. Specifically, version 10.9 is explicitly selected when building x86_64 (and universal2) wheels. Only arm64 wheels select version 11.0. See here for details:

https://github.com/pypa/cibuildwheel/blob/2e6cbe2435ef410156319c98625002ed76e08785/cibuildwheel/macos.py#L217-L232

I have tried it on AccessControl master and the wheels get built just fine, see https://github.com/zopefoundation/AccessControl/actions/runs/3445282682/jobs/5748817908

You don't happen to know how to get the equivalent of "python version > 3.10" into a GHA expression, do you? That list of specific versions as condition irks me.