### PR TITLE
Fix GHA: ubuntu-latest no longer contains Python 2.7 up to 3.6.

### DIFF
--- a/config/config-package.py
+++ b/config/config-package.py
@@ -19,7 +19,7 @@ META_HINT_MARKDOWN = """\
 Generated from:
 https://github.com/zopefoundation/meta/tree/master/config/{config_type}
 --> """
-FUTURE_PYTHON_VERSION = "3.12.0-alpha.1"
+FUTURE_PYTHON_VERSION = "3.12.0-alpha.2"
 
 
 def copy_with_meta(

--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -21,12 +21,12 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - ubuntu
+        - ubuntu-20.04
 {% if with_windows %}
-        - windows
+        - windows-latest
 {% endif %}
 {% if with_macos %}
-        - macos
+        - macos-latest
 {% endif %}
         config:
         # [Python version, tox env]
@@ -61,27 +61,27 @@ jobs:
         exclude:
 {% endif %}
 {% if with_windows %}
-          - { os: windows, config: ["3.9",   "lint"] }
+          - { os: windows-latest, config: ["3.9",   "lint"] }
   {% if with_docs %}
-          - { os: windows, config: ["3.9",   "docs"] }
+          - { os: windows-latest, config: ["3.9",   "docs"] }
   {% endif %}
-          - { os: windows, config: ["3.9",   "coverage"] }
+          - { os: windows-latest, config: ["3.9",   "coverage"] }
 {% endif %}
 {% if with_macos %}
-          - { os: macos, config: ["3.9",   "lint"] }
+          - { os: macos-latest, config: ["3.9",   "lint"] }
   {% if with_docs %}
-          - { os: macos, config: ["3.9",   "docs"] }
+          - { os: macos-latest, config: ["3.9",   "docs"] }
   {% endif %}
-          - { os: macos, config: ["3.9",   "coverage"] }
+          - { os: macos-latest, config: ["3.9",   "coverage"] }
           # macOS/Python 3.11 is set up for universal2 architecture
           # which causes build and package selection issues.
-          - { os: macos, config: ["3.11",  "py311"] }
+          - { os: macos-latest, config: ["3.11",  "py311"] }
 {% endif %}
 {% for line in gha_additional_exclude %}
           %(line)s
 {% endfor %}
 
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 {% if with_windows or with_macos %}
     name: ${{ matrix.os }}-${{ matrix.config[1] }}

--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -21,12 +21,12 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - ubuntu-20.04
+        - ["ubuntu", "ubuntu-20.04"]
 {% if with_windows %}
-        - windows-latest
+        - ["windows", "windows-latest"]
 {% endif %}
 {% if with_macos %}
-        - macos-latest
+        - ["macos", "macos-latest"]
 {% endif %}
         config:
         # [Python version, tox env]
@@ -61,30 +61,30 @@ jobs:
         exclude:
 {% endif %}
 {% if with_windows %}
-          - { os: windows-latest, config: ["3.9",   "lint"] }
+          - { os: ["windows", "windows-latest"], config: ["3.9",   "lint"] }
   {% if with_docs %}
-          - { os: windows-latest, config: ["3.9",   "docs"] }
+          - { os: ["windows", "windows-latest"], config: ["3.9",   "docs"] }
   {% endif %}
-          - { os: windows-latest, config: ["3.9",   "coverage"] }
+          - { os: ["windows", "windows-latest"], config: ["3.9",   "coverage"] }
 {% endif %}
 {% if with_macos %}
-          - { os: macos-latest, config: ["3.9",   "lint"] }
+          - { os: ["macos", "macos-latest"], config: ["3.9",   "lint"] }
   {% if with_docs %}
-          - { os: macos-latest, config: ["3.9",   "docs"] }
+          - { os: ["macos", "macos-latest"], config: ["3.9",   "docs"] }
   {% endif %}
-          - { os: macos-latest, config: ["3.9",   "coverage"] }
+          - { os: ["macos", "macos-latest"], config: ["3.9",   "coverage"] }
           # macOS/Python 3.11 is set up for universal2 architecture
           # which causes build and package selection issues.
-          - { os: macos-latest, config: ["3.11",  "py311"] }
+          - { os: ["macos", "macos-latest"], config: ["3.11",  "py311"] }
 {% endif %}
 {% for line in gha_additional_exclude %}
           %(line)s
 {% endfor %}
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os[1] }}
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 {% if with_windows or with_macos %}
-    name: ${{ matrix.os }}-${{ matrix.config[1] }}
+    name: ${{ matrix.os[0] }}-${{ matrix.config[1] }}
 {% else %}
     name: ${{ matrix.config[1] }}
 {% endif %}

--- a/config/default/tox-lint.j2
+++ b/config/default/tox-lint.j2
@@ -19,6 +19,7 @@ deps =
 
 [testenv:isort-apply]
 basepython = python3
+skip_install = true
 commands_pre =
 deps =
     isort


### PR DESCRIPTION
Used in https://github.com/zopefoundation/zope.copy/pull/9