### PR TITLE
Update manylinux docker images for i686 and x86_64 from 2010 to 2014

### DIFF
--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -364,7 +364,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9"]
-        image: [manylinux2010_x86_64, manylinux2010_i686, manylinux2014_aarch64]
+        image: [manylinux2014_x86_64, manylinux2014_i686, manylinux2014_aarch64]
 
     steps:
 {% set cache_key = "${{ runner.os }}-pip_manylinux-${{ matrix.image }}-${{ matrix.python-version }}" %}
@@ -373,7 +373,7 @@ jobs:
       - name: Update pip
         run: pip install -U pip
       - name: Build %(package_name)s (x86_64)
-        if: matrix.image == 'manylinux2010_x86_64'
+        if: matrix.image == 'manylinux2014_x86_64'
         # An alternate way to do this is to run the container directly with a uses:
         # and then the script runs inside it. That may work better with caching.
         # See https://github.com/pyca/bcrypt/blob/f6b5ee2eda76d077c531362ac65e16f045cf1f29/.github/workflows/wheel-builder.yml
@@ -382,7 +382,7 @@ jobs:
         run: |
           bash .manylinux.sh
       - name: Build %(package_name)s (i686)
-        if: matrix.image == 'manylinux2010_i686'
+        if: matrix.image == 'manylinux2014_i686'
         env:
           DOCKER_IMAGE: quay.io/pypa/${{ matrix.image }}
           PRE_CMD: linux32


### PR DESCRIPTION
Fixes #182 

See test run with `Acquisition` at https://github.com/zopefoundation/Acquisition/actions/runs/3794775048. The logs for the manylinux builds confirm that a Python 3.11 binary egg is built.