### PR TITLE
Now that Python 2 support is gone we can require tox 4

### DIFF
--- a/config/c-code/tox.ini.j2
+++ b/config/c-code/tox.ini.j2
@@ -3,7 +3,7 @@
 {% set testenv_setenv = ['pure: PURE_PYTHON=1', '!pure-!pypy3: PURE_PYTHON=0'] + testenv_setenv %}
 {% set coverage_setenv = ['PURE_PYTHON=1'] + coverage_setenv %}
 [tox]
-minversion = 3.18
+minversion = 4.0
 envlist =
     lint
     py37,py37-pure


### PR DESCRIPTION
That way local installs where we have no control over the version of `tox` used can't get too badly out of sync with GitHub Actions installs, which will always grab the latest version.