### PR TITLE
Add option to set environment variables for the GHA test step

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -308,6 +308,9 @@ updated. Example:
         "cffi",
         "python-ldap",
         ]
+    test-enviroment = [
+        "TEST_DSN: 'host=localhost port=5432 user=postgres'"
+        ]
     test-commands = [
         "tox -f ${{ matrix.config[1] }}",
         ]
@@ -594,6 +597,10 @@ additional-build-dependencies
   building a package with C extensions. This is used for the ``c-code``
   template to work around issues on macOS where setuptools attempts to retrieve
   wheels and convert them to eggs multiple times.
+
+test-environment
+  Environment variables to be set during the test run. This option has to be a
+  list of strings.
 
 test-commands
   Replacement for the test command in ``tests.yml``.

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -462,6 +462,7 @@ class PackageConfiguration:
         additional_install = self.gh_option('additional-install')
         additional_build_dependencies = self.gh_option(
             'additional-build-dependencies')
+        test_environment = self.gh_option('test-environment')
         test_commands = self.gh_option('test-commands')
         self.copy_with_meta(
             'tests.yml.j2',
@@ -471,6 +472,7 @@ class PackageConfiguration:
             gha_additional_exclude=additional_exclude,
             gha_additional_install=additional_install,
             gha_additional_build_dependencies=additional_build_dependencies,
+            gha_test_environment=test_environment,
             gha_test_commands=test_commands,
             package_name=self.path.name,
             services=services,

--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -105,6 +105,12 @@ jobs:
         %(line)s
 {% endfor %}
     - name: Test
+{% if gha_test_environment %}
+      env:
+      {% for line in gha_test_environment %}
+        %(line)s
+      {% endfor %}
+{% endif %}
 {% if gha_test_commands %}
       run: |
       {% for line in gha_test_commands %}


### PR DESCRIPTION
This PR adds an option to set values for the `env` variable in the GHA `Test`step.