### PR TITLE
Upgrade PyPy to 3.9.

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -293,8 +293,8 @@ updated. Example:
         "- [\"3.8\",   \"py38-slim\"]",
         ]
     additional-exclude = [
-        "- { os: windows, config: [\"pypy-3.7\", \"pypy\"] }",
-        "- { os: macos, config: [\"pypy-3.7\", \"pypy\"] }",
+        "- { os: windows, config: [\"pypy-3.9\", \"pypy\"] }",
+        "- { os: macos, config: [\"pypy-3.9\", \"pypy\"] }",
         ]
     steps-before-checkout = [
         "- name: \"Set some Postgres settings\"",

--- a/config/c-code/tests-strategy.j2
+++ b/config/c-code/tests-strategy.j2
@@ -3,7 +3,7 @@
       matrix:
         python-version:
 {% if with_pypy %}
-          - "pypy-3.7"
+          - "pypy-3.9"
 {% endif %}
           - "3.7"
           - "3.8"
@@ -19,7 +19,7 @@
 {% endif %}
 {% if with_pypy %}
           - os: macos-11
-            python-version: "pypy-3.7"
+            python-version: "pypy-3.9"
 {% endif %}
 {% for line in gha_additional_exclude %}
           %(line)s

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -133,6 +133,16 @@ def handle_command_line_arguments():
     return args
 
 
+def prepend_space(text):
+    """Prepend `text` which a space if not empty.
+
+    This prevents trailing whitespace for empty values.
+    """
+    if text:
+        text = f' {text}'
+    return text
+
+
 class PackageConfiguration:
     add_coveragerc = False
     rm_coveragerc = False
@@ -278,22 +288,15 @@ class PackageConfiguration:
             'check-manifest', 'additional-ignores')
         check_manifest_ignore_bad_ideas = self.cfg_option(
             'check-manifest', 'ignore-bad-ideas')
-        isort_known_third_party = self.cfg_option(
-            'isort', 'known_third_party',
-            default=' six, docutils, pkg_resources')
-        isort_known_zope = self.cfg_option('isort', 'known_zope', default='')
-        isort_known_first_party = self.cfg_option(
-            'isort', 'known_first_party', default='')
-        isort_known_local_folder = self.meta_cfg['isort'].get(
-            'known_local_folder', '')
-        for var in (
-            'isort_known_third_party',
-            'isort_known_zope',
-            'isort_known_first_party',
-        ):
-            if locals()[var]:
-                # Avoid whitespace at end of line if empty:
-                locals()[var] = ' ' + locals()[var]
+        isort_known_third_party = prepend_space(
+            self.cfg_option('isort', 'known_third_party',
+                            default='six, docutils, pkg_resources'))
+        isort_known_zope = prepend_space(
+            self.cfg_option('isort', 'known_zope', default=''))
+        isort_known_first_party = prepend_space(
+            self.cfg_option('isort', 'known_first_party', default=''))
+        isort_known_local_folder = prepend_space(
+            self.meta_cfg['isort'].get('known_local_folder', ''))
 
         zest_releaser_options = self.meta_cfg['zest-releaser'].get(
             'options', [])

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -290,7 +290,7 @@ class PackageConfiguration:
             'check-manifest', 'ignore-bad-ideas')
         isort_known_third_party = prepend_space(
             self.cfg_option('isort', 'known_third_party',
-                            default='six, docutils, pkg_resources'))
+                            default='six, docutils, pkg_resources, pytz'))
         isort_known_zope = prepend_space(
             self.cfg_option('isort', 'known_zope', default=''))
         isort_known_first_party = prepend_space(

--- a/config/default/setup.cfg.j2
+++ b/config/default/setup.cfg.j2
@@ -46,9 +46,9 @@ ignore-bad-ideas =
 force_single_line = True
 combine_as_imports = True
 sections = FUTURE,STDLIB,THIRDPARTY,ZOPE,FIRSTPARTY,LOCALFOLDER
-known_third_party = %(isort_known_third_party)s
-known_zope = %(isort_known_zope)s
-known_first_party = %(isort_known_first_party)s
+known_third_party =%(isort_known_third_party)s
+known_zope =%(isort_known_zope)s
+known_first_party =%(isort_known_first_party)s
 {% if isort_known_local_folder %}
 known_local_folder = %(isort_known_local_folder)s
 {% endif %}

--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -40,7 +40,7 @@ jobs:
         - ["%(future_python_version)s",  "py312"]
 {% endif %}
 {% if with_pypy %}
-        - ["pypy-3.7", "pypy3"]
+        - ["pypy-3.9", "pypy3"]
 {% endif %}
 {% if with_docs %}
         - ["3.9",   "docs"]


### PR DESCRIPTION
That version seems to run more stable, see https://github.com/zopefoundation/zc.catalog/pull/16

Plus fix whitespace in isort config. This never seems to have worked since I implemented it a year ago. Shame on me.