### PR TITLE
Inherit the `allowlist_externals` to the coverage env.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.1.0
+      rev: v4.4.0
       hooks:
           - id: trailing-whitespace
           - id: end-of-file-fixer
@@ -11,17 +11,17 @@ repos:
           - id: debug-statements
             language_version: python3
     - repo: https://github.com/PyCQA/flake8
-      rev: 4.0.1
+      rev: 6.0.0
       hooks:
           - id: flake8
             language_version: python3
-            additional_dependencies: [flake8-typing-imports==1.9.0]
+            additional_dependencies: [flake8-typing-imports==1.14.0]
     - repo: https://github.com/pre-commit/mirrors-autopep8
-      rev: v1.6.0
+      rev: v2.0.1
       hooks:
           - id: autopep8
     - repo: https://github.com/timothycrosley/isort
-      rev: 5.10.1
+      rev: 5.12.0
       hooks:
       - id: isort
         args: [--filter-files]
@@ -38,7 +38,7 @@ repos:
             additional_dependencies: [pygments, restructuredtext_lint]
 # This can deal with sphinx directives
     - repo: https://github.com/myint/rstcheck
-      rev: "3f92957478422df87bd730abde66f089cc1ee19b"  # Use the sha / tag you want to point at
+      rev: "v6.1.1"
       hooks:
       - id: rstcheck
         args: [--ignore-messages, Duplicate implicit target.*]

--- a/config/zope-product/tox.ini.j2
+++ b/config/zope-product/tox.ini.j2
@@ -75,6 +75,7 @@ commands =
 basepython = %(coverage_basepython)s
 skip_install = true
 allowlist_externals =
+    {[testenv]allowlist_externals}
     mkdir
 {% if coverage_setenv %}
 setenv =


### PR DESCRIPTION
This is needed for zope.sqlachemy.

Used in https://github.com/zopefoundation/zope.sqlalchemy/pull/77