### PR TITLE
Do not run Python 3.12 on MacOS

### DIFF
--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -65,9 +65,10 @@ jobs:
           - { os: ["macos", "macos-11"], config: ["3.9",   "docs"] }
   {% endif %}
           - { os: ["macos", "macos-11"], config: ["3.9",   "coverage"] }
-          # macOS/Python 3.11 is set up for universal2 architecture
+          # macOS/Python 3.11+ is set up for universal2 architecture
           # which causes build and package selection issues.
           - { os: ["macos", "macos-11"], config: ["3.11",  "py311"] }
+          - { os: ["macos", "macos-11"], config: ["%(future_python_version)s",  "py312"] }
 {% endif %}
 {% for line in gha_additional_exclude %}
           %(line)s


### PR DESCRIPTION
Python 3.12 seems to need the same treatment like Python 3.11.

Used in https://github.com/zopefoundation/Zope/pull/1103