### PR TITLE
Ignore generated translation files

### DIFF
--- a/config/default/gitignore.j2
+++ b/config/default/gitignore.j2
@@ -1,5 +1,6 @@
 *.dll
 *.egg-info/
+*.mo
 *.profraw
 *.pyc
 *.pyo


### PR DESCRIPTION
This came up in conjunction with the partial Japanese translation of the Zope docs. We don't want to ship the generated files, just the sources.