### PR TITLE
Add toolkit template.

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -35,9 +35,9 @@ packages:
     ``tox.ini`` to be able to pin the installed dependency versions the same
     way ``buildout.cfg`` does it.
 
-* groktoolkit
+* toolkit
 
-  - Configuration currently only used for the groktoolkit repository.
+  - Configuration used for the zopetoolkit and groktoolkit repositories.
 
 Contents
 --------

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -115,7 +115,7 @@ def handle_command_line_arguments():
             'c-code',
             'pure-python',
             'zope-product',
-            'groktoolkit',
+            'toolkit',
         ],
         default=None,
         dest='type',

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -497,10 +497,11 @@ class PackageConfiguration:
         if self.config_type == 'c-code' \
                 and 'include *.sh' not in additional_manifest_rules:
             additional_manifest_rules.insert(0, 'include *.sh')
-        self.copy_with_meta(
-            'MANIFEST.in.j2', self.path / 'MANIFEST.in', self.config_type,
-            additional_rules=additional_manifest_rules,
-            with_docs=self.with_docs, with_appveyor=self.with_appveyor)
+        if self.config_type != 'toolkit':
+            self.copy_with_meta(
+                'MANIFEST.in.j2', self.path / 'MANIFEST.in', self.config_type,
+                additional_rules=additional_manifest_rules,
+                with_docs=self.with_docs, with_appveyor=self.with_appveyor)
 
     def appveyor(self):
         appveyor_global_env_vars = self.meta_cfg['appveyor'].get(

--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -1,3 +1,8 @@
+{% if config_type == 'toolkit' %}
+{% set with_coverage = False %}
+{% else %}
+{% set with_coverage = True %}
+{% endif %}
 name: tests
 
 on:
@@ -45,7 +50,9 @@ jobs:
 {% if with_docs %}
         - ["3.9",   "docs"]
 {% endif %}
+{% if with_coverage %}
         - ["3.9",   "coverage"]
+{% endif %}
 {% for line in gha_additional_config %}
         %(line)s
 {% endfor %}

--- a/config/toolkit/packages.txt
+++ b/config/toolkit/packages.txt
@@ -1,0 +1,4 @@
+# Toolkit repositories configured using this template are listed here.
+# Do not edit the file by hand but use the script config-package.py as
+# described in README.rst
+zopetoolkit

--- a/config/toolkit/tox.ini.j2
+++ b/config/toolkit/tox.ini.j2
@@ -1,0 +1,81 @@
+{% set with_coverage = False %}
+{% include 'tox-envlist.j2' %}
+
+[testenv]
+skip_install = true
+deps =
+    zc.buildout >= 3.0.1
+    wheel > 0.37
+{% for line in testenv_deps %}
+    %(line)s
+{% endfor %}
+{% if testenv_setenv or with_future_python %}
+setenv =
+  {% for line in testenv_setenv %}
+    %(line)s
+  {% endfor %}
+  {% if with_future_python %}
+    py312: VIRTUALENV_PIP=23.1.2
+    py312: PIP_REQUIRE_VIRTUALENV=0
+  {% endif %}
+{% endif %}
+commands_pre =
+{% if testenv_commands_pre %}
+  {% for line in testenv_commands_pre %}
+    %(line)s
+  {% endfor %}
+{% else %}
+    {envbindir}/buildout -nc {toxinidir}/buildout.cfg buildout:directory={envdir}
+{% endif %}
+commands =
+{% if testenv_commands %}
+  {% for line in testenv_commands %}
+    %(line)s
+  {% endfor %}
+{% else %}
+    Error! set set `[tox] testenv-commands` in .meta.toml
+{% endif %}
+{% for line in testenv_additional %}
+%(line)s
+{% endfor %}
+
+[testenv:lint]
+basepython = python3
+commands_pre =
+{% if use_flake8 %}
+    mkdir -p {toxinidir}/parts/flake8
+allowlist_externals =
+    mkdir
+{% endif %}
+commands =
+{% if use_flake8 %}
+    isort --check-only --diff {toxinidir}/docs%(isort_additional_sources)s
+    flake8 {toxinidir}/docs%(flake8_additional_sources)s
+{% endif %}
+deps =
+{% if use_flake8 %}
+    flake8
+    isort
+
+[testenv:isort-apply]
+basepython = python3
+skip_install = true
+commands_pre =
+deps =
+    isort
+commands =
+    isort {toxinidir}/docs%(isort_additional_sources)s []
+{% endif %}
+{% if with_docs %}
+
+[testenv:docs]
+basepython = python3
+deps =
+   -r doc-requirements.txt
+commands_pre =
+commands =
+    sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
+{% if with_sphinx_doctests %}
+    sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest
+{% endif %}
+{% endif %}


### PR DESCRIPTION
Will be used for zopetoolkit and groktoolkit.

The previous mentioning of a groktoolkit template was not true, it never made it out of my hard disk into the repository as it was not ready.

Used in https://github.com/zopefoundation/zopetoolkit/pull/57.