### PR TITLE
Switch Python 3.12 to non-future and change with-future-python behavior

### DIFF
--- a/config/c-code/manylinux-install.sh.j2
+++ b/config/c-code/manylinux-install.sh.j2
@@ -30,13 +30,14 @@ yum -y install libffi-devel
 tox_env_map() {
     case $1 in
 {% if with_future_python %}
-        *"cp312"*) echo 'py312';;
+        *"cp313"*) echo 'py313';;
 {% endif %}
         *"cp37"*) echo 'py37';;
         *"cp38"*) echo 'py38';;
         *"cp39"*) echo 'py39';;
         *"cp310"*) echo 'py310';;
         *"cp311"*) echo 'py311';;
+        *"cp312"*) echo 'py312';;
         *) echo 'py';;
     esac
 }
@@ -45,15 +46,16 @@ tox_env_map() {
 for PYBIN in /opt/python/*/bin; do
     if \
 {% if with_future_python %}
-       [[ "${PYBIN}" == *"cp312"* ]] || \
+       [[ "${PYBIN}" == *"cp313"* ]] || \
 {% endif %}
        [[ "${PYBIN}" == *"cp311"* ]] || \
+       [[ "${PYBIN}" == *"cp312"* ]] || \
        [[ "${PYBIN}" == *"cp37"* ]] || \
        [[ "${PYBIN}" == *"cp38"* ]] || \
        [[ "${PYBIN}" == *"cp39"* ]] || \
        [[ "${PYBIN}" == *"cp310"* ]] ; then
 {% if with_future_python %}
-        if [[ "${PYBIN}" == *"cp312"* ]] ; then
+        if [[ "${PYBIN}" == *"cp313"* ]] ; then
             "${PYBIN}/pip" install --pre -e /io/
             "${PYBIN}/pip" wheel /io/ --pre -w wheelhouse/
         else

--- a/config/c-code/tox.ini.j2
+++ b/config/c-code/tox.ini.j2
@@ -11,8 +11,9 @@ envlist =
     py39,py39-pure
     py310,py310-pure
     py311,py311-pure
-{% if with_future_python %}
     py312,py312-pure
+{% if with_future_python %}
+    py313,py313-pure
 {% endif %}
 {% if with_pypy %}
     pypy3

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -23,7 +23,7 @@ META_HINT_MARKDOWN = """\
 Generated from:
 https://github.com/zopefoundation/meta/tree/master/config/{config_type}
 --> """
-FUTURE_PYTHON_VERSION = "3.12.0-rc.3"
+FUTURE_PYTHON_VERSION = ""
 DEFAULT = object()
 
 
@@ -226,7 +226,10 @@ class PackageConfiguration:
 
     @cached_property
     def with_future_python(self):
-        return self._set_python_config_value('future-python')
+        if FUTURE_PYTHON_VERSION:
+            return self._set_python_config_value('future-python')
+        else:
+            return False
 
     @cached_property
     def with_docs(self):

--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -41,8 +41,9 @@ jobs:
         - ["3.9",   "py39"]
         - ["3.10",  "py310"]
         - ["3.11",  "py311"]
+        - ["3.12",  "py312"]
 {% if with_future_python %}
-        - ["%(future_python_version)s",  "py312"]
+        - ["%(future_python_version)s",  "py313"]
 {% endif %}
 {% if with_pypy %}
         - ["pypy-3.9", "pypy3"]
@@ -75,7 +76,8 @@ jobs:
           # macOS/Python 3.11+ is set up for universal2 architecture
           # which causes build and package selection issues.
           - { os: ["macos", "macos-11"], config: ["3.11",  "py311"] }
-          - { os: ["macos", "macos-11"], config: ["%(future_python_version)s",  "py312"] }
+          - { os: ["macos", "macos-11"], config: ["3.12",  "py312"] }
+          - { os: ["macos", "macos-11"], config: ["%(future_python_version)s",  "py313"] }
 {% endif %}
 {% for line in gha_additional_exclude %}
           %(line)s

--- a/config/default/tox-envlist.j2
+++ b/config/default/tox-envlist.j2
@@ -7,8 +7,9 @@ envlist =
     py39
     py310
     py311
-{% if with_future_python %}
     py312
+{% if with_future_python %}
+    py313
 {% endif %}
 {% if with_pypy %}
     pypy3

--- a/config/default/tox-testenv.j2
+++ b/config/default/tox-testenv.j2
@@ -6,7 +6,7 @@ package = wheel
 wheel_build_env = .pkg
 {% endif %}
 {% if with_future_python %}
-pip_pre = py312: true
+pip_pre = py313: true
 {% endif %}
 deps =
   {% for line in testenv_deps %}
@@ -15,16 +15,14 @@ deps =
   {% if with_sphinx_doctests and with_future_python %}
     Sphinx
   {% endif %}
-{% if testenv_setenv or with_future_python %}
 setenv =
+{% if testenv_setenv %}
   {% for line in testenv_setenv %}
     %(line)s
   {% endfor %}
-  {% if with_future_python %}
+{% endif %}
     py312: VIRTUALENV_PIP=23.1.2
     py312: PIP_REQUIRE_VIRTUALENV=0
-  {% endif %}
-{% endif %}
 {% if testenv_commands_pre %}
 commands_pre =
   {% for line in testenv_commands_pre %}

--- a/config/toolkit/tox.ini.j2
+++ b/config/toolkit/tox.ini.j2
@@ -9,16 +9,14 @@ deps =
 {% for line in testenv_deps %}
     %(line)s
 {% endfor %}
-{% if testenv_setenv or with_future_python %}
 setenv =
+{% if testenv_setenv %}
   {% for line in testenv_setenv %}
     %(line)s
   {% endfor %}
-  {% if with_future_python %}
+{% endif %}
     py312: VIRTUALENV_PIP=23.1.2
     py312: PIP_REQUIRE_VIRTUALENV=0
-  {% endif %}
-{% endif %}
 commands_pre =
 {% if testenv_commands_pre %}
   {% for line in testenv_commands_pre %}

--- a/config/zope-product/tox.ini.j2
+++ b/config/zope-product/tox.ini.j2
@@ -9,16 +9,14 @@ deps =
 {% for line in testenv_deps %}
     %(line)s
 {% endfor %}
-{% if testenv_setenv or with_future_python %}
 setenv =
+{% if testenv_setenv %}
   {% for line in testenv_setenv %}
     %(line)s
   {% endfor %}
-  {% if with_future_python %}
+{% endif %}
     py312: VIRTUALENV_PIP=23.1.2
     py312: PIP_REQUIRE_VIRTUALENV=0
-  {% endif %}
-{% endif %}
 commands_pre =
 {% if testenv_commands_pre %}
   {% for line in testenv_commands_pre %}


### PR DESCRIPTION
This PR does two things:

- move Python 3.12 to the list of standard non-future Pythons
- prepare places that want to use future Pythons by using `py313`
- redefine `FUTURE_PYTHON_VERSION` to an empty string
- only render future python-related template items if `FUTURE_PYTHON_VERSION` is not empty

With the last two changes individual packages do not need to turn off their `with-future-python` flag during those times when the Python release is finished and no prerelease exists for the next Python version.