### PR TITLE
Add ability to specify additional RTD build options

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -377,6 +377,12 @@ updated. Example:
         "*.mo",
         ]
 
+    [readthedocs]
+    build-extra = [
+        "apt_packages:",
+        "  - libldap2-dev",
+        ]
+
 
 Meta Options
 ````````````
@@ -688,7 +694,6 @@ options
   (Additional) options used to configure ``zest.releaser``. This option has to
   be a list of strings and defaults to an empty list.
 
-
 git options
 ```````````
 
@@ -696,6 +701,16 @@ The corresponding section is named: ``[git]``.
 
 ignore
   Additional lines to be added to the ``.gitignore`` file. This option has to
+  be a list of strings and defaults to an empty list.
+
+ReadTheDocs options
+```````````````````
+
+The corresponding section is named: ``[readthedocs]``.
+
+build-extra
+  Additional lines to be added to the ``build`` configuration in the
+  ReadTheDocs configuration file ``.readthedocs.yaml``. This option has to
   be a list of strings and defaults to an empty list.
 
 Hints

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -332,9 +332,13 @@ class PackageConfiguration:
         )
 
     def readthedocs(self):
+        build_extra = self.cfg_option(
+            'readthedocs', 'build-extra', default=[])
         self.copy_with_meta(
-            'readthedocs.yaml.j2', self.path / '.readthedocs.yaml',
-            self.config_type
+            'readthedocs.yaml.j2',
+            self.path / '.readthedocs.yaml',
+            self.config_type,
+            build_extra=build_extra,
         )
 
     def coveragerc(self):

--- a/config/default/readthedocs.yaml.j2
+++ b/config/default/readthedocs.yaml.j2
@@ -9,6 +9,11 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+{% if build_extra %}
+  {% for line in build_extra %}
+  %(line)s
+  {% endfor %}
+{% endif %}
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
This adds support for additional lines to be inserted into the `.readthedocs.yaml` build configuration section. This is useful to e.g. install additional packages in the OS.