### PR TITLE
Don't call "git add" if the --no-commit flag is set

### DIFF
--- a/config/config-package.py
+++ b/config/config-package.py
@@ -588,7 +588,8 @@ class PackageConfiguration:
         with change_dir(self.path):
             # We have to add it here otherwise the linter complains
             # that it is not added.
-            call('git', 'add', 'CONTRIBUTING.md')
+            if self.args.commit:
+                call('git', 'add', 'CONTRIBUTING.md')
 
         self.coveragerc()
         self.manylinux_sh()
@@ -606,13 +607,13 @@ class PackageConfiguration:
                 call('git', 'rm', '.travis.yml')
             if self.rm_coveragerc:
                 call('git', 'rm', '.coveragerc')
-            if self.add_coveragerc:
+            if self.add_coveragerc and self.args.commit:
                 call('git', 'add', '.coveragerc')
-            if self.with_appveyor:
+            if self.with_appveyor and self.args.commit:
                 call('git', 'add', 'appveyor.yml')
-            if self.with_docs:
+            if self.with_docs and self.args.commit:
                 call('git', 'add', '.readthedocs.yaml')
-            if self.add_manylinux:
+            if self.add_manylinux and self.args.commit:
                 call('git', 'add', '.manylinux.sh', '.manylinux-install.sh')
             # Remove empty sections:
             meta_cfg = {k: v for k, v in self.meta_cfg.items() if v}


### PR DESCRIPTION
This change solves an ongoing annoyance for my own workflow: I always use `--no-commit` because I want to eyeball all changes. But several places use `git add`, which puts the changes into the git staging area and thus out of reach of `git diff`. I always have to do `git restore --staged` for those files. With this change `git add` is not done when `--no-commit` is used.