### PR TITLE
Specify FUTURE_PYTHON_VERSION as version range

### DIFF
--- a/config/config-package.py
+++ b/config/config-package.py
@@ -23,7 +23,7 @@ META_HINT_MARKDOWN = """\
 Generated from:
 https://github.com/zopefoundation/meta/tree/master/config/{config_type}
 --> """
-FUTURE_PYTHON_VERSION = ""
+FUTURE_PYTHON_VERSION = "3.13.0-alpha - 3.13.0"
 DEFAULT = object()
 
 
@@ -226,10 +226,7 @@ class PackageConfiguration:
 
     @cached_property
     def with_future_python(self):
-        if FUTURE_PYTHON_VERSION:
-            return self._set_python_config_value('future-python')
-        else:
-            return False
+        return self._set_python_config_value('future-python')
 
     @cached_property
     def with_docs(self):


### PR DESCRIPTION
See https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#specifying-a-python-version and scroll down to `hyphen ranges`: It's apparently possible to specify a range of versions for a Python version to be used with the GitHub `setup-python` action. That way we won't have to update this package for every new prerelease. It also means testing for the value of `FUTURE_PYTHON_VERSION` to determine if `with_future_python` has to be set is no longer necessary. Only the package's `future-python` setting is considered.

This is not fully tested because there's no Python 3.13 preprelease yet.