### PR TITLE
Revert "Specify FUTURE_PYTHON_VERSION as version range"

### DIFF
--- a/config/config-package.py
+++ b/config/config-package.py
@@ -23,7 +23,7 @@ META_HINT_MARKDOWN = """\
 Generated from:
 https://github.com/zopefoundation/meta/tree/master/config/{config_type}
 --> """
-FUTURE_PYTHON_VERSION = "3.13.0-alpha - 3.13.0"
+FUTURE_PYTHON_VERSION = ""
 DEFAULT = object()
 
 
@@ -226,7 +226,10 @@ class PackageConfiguration:
 
     @cached_property
     def with_future_python(self):
-        return self._set_python_config_value('future-python')
+        if FUTURE_PYTHON_VERSION:
+            return self._set_python_config_value('future-python')
+        else:
+            return False
 
     @cached_property
     def with_docs(self):

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -23,7 +23,7 @@ META_HINT_MARKDOWN = """\
 Generated from:
 https://github.com/zopefoundation/meta/tree/master/config/{config_type}
 --> """
-FUTURE_PYTHON_VERSION = ""
+FUTURE_PYTHON_VERSION = "3.13.0-alpha - 3.13.0"
 DEFAULT = object()
 
 


### PR DESCRIPTION
Reverts zopefoundation/meta#218

Until there is a Python 3.13 alpha version at GHA the changes break running `config-package.py` if `with-future-python` is `true`. I think the merge was done too early.

We can revert this revert when the 3.13 alpha finally appears.

Needed for https://github.com/zopefoundation/zope.index/pull/45