### PR TITLE
Address issues from PR #216

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -98,7 +98,7 @@ Preparation
 
 The script needs a ``venv`` with some packages installed::
 
-    $ python3 -m venv .
+    $ python3.11 -m venv .
     $ bin/pip install -r requirements.txt
 
 To use the configuration provided here in a package call the following script::
@@ -272,7 +272,7 @@ updated. Example:
         "extend-ignore = D203, W503",
         ]
     additional-plugins = [
-        "maccabe"
+        "mccabe",
         ]
     additional-sources = "testproj foo bar.py"
 
@@ -527,7 +527,7 @@ additional-config
 
 additional-plugins
   Some packages want to have additional flake8 plugins installed.
-  *Caution:* This option has to be a list of strings.
+  This option is a list of strings.
 
 additional-sources
   Sometimes not only ``src`` and ``setup.py`` contain Python code to be checked

--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -35,7 +35,7 @@ jobs:
 {% endif %}
         config:
         # [Python version, tox env]
-        - ["3.9"],  "release-check"]
+        - ["3.9",   "release-check"]
         - ["3.9",   "lint"]
         - ["3.7",   "py37"]
         - ["3.8",   "py38"]

--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -35,6 +35,7 @@ jobs:
 {% endif %}
         config:
         # [Python version, tox env]
+        - ["3.9"],  "release-check"]
         - ["3.9",   "lint"]
         - ["3.7",   "py37"]
         - ["3.8",   "py38"]
@@ -61,6 +62,7 @@ jobs:
         exclude:
 {% endif %}
 {% if with_windows %}
+          - { os: ["windows", "windows-latest"], config: ["3.9",   "release-check"] }
           - { os: ["windows", "windows-latest"], config: ["3.9",   "lint"] }
   {% if with_docs %}
           - { os: ["windows", "windows-latest"], config: ["3.9",   "docs"] }
@@ -68,6 +70,7 @@ jobs:
           - { os: ["windows", "windows-latest"], config: ["3.9",   "coverage"] }
 {% endif %}
 {% if with_macos %}
+          - { os: ["macos", "macos-11"], config: ["3.9",   "release-check"] }
           - { os: ["macos", "macos-11"], config: ["3.9",   "lint"] }
   {% if with_docs %}
           - { os: ["macos", "macos-11"], config: ["3.9",   "docs"] }


### PR DESCRIPTION
This PR addresses the issues found after merging #216.

- prescribe Python 3.11 for using this package
- fix documentation to rename maccabe to mccabe
- fix documentation wording for flake8 additional-plugins
- add release-check test to GHA steps