### PR TITLE
Revert "Fix path to ``test`` script on Windows"

### DIFF
--- a/config/zope-product/tox.ini.j2
+++ b/config/zope-product/tox.ini.j2
@@ -31,7 +31,7 @@ commands =
     %(line)s
   {% endfor %}
 {% else %}
-    {envdir}/bin/test {posargs:-cv}
+    {envbindir}/test {posargs:-cv}
 {% endif %}
 {% for line in testenv_additional %}
 %(line)s
@@ -108,7 +108,7 @@ commands =
     %(line)s
   {% endfor %}
 {% else %}
-    coverage run {envdir}/bin/test {posargs:-cv}
+    coverage run {envbindir}/test {posargs:-cv}
 {% endif %}
     coverage html
     coverage report -m --fail-under=%(fail_under)s


### PR DESCRIPTION
Reverts zopefoundation/meta#157

Reason: In https://github.com/zopefoundation/DateTime/pull/57 windows tests break again and I found another solution there.