### PR TITLE
Support Python 3.13a3 by installing not yet released packages.

### DIFF
--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -96,7 +96,22 @@ jobs:
     steps:
 {% include 'tests-cache.j2' %}
 
+{% if with_future_python %}
+      - name: Install Build Dependencies (%(future_python_version)s)
+        if: matrix.python-version == '%(future_python_version)s'
+        run: |
+          pip install -U pip
+          pip install -U setuptools wheel twine
+          # cffi will probably have no public release until a Python 3.13 beta
+          # or even RC release, see https://github.com/python-cffi/cffi/issues/23
+          pip install -U "cffi @ https://github.com/python-cffi/cffi/archive/refs/heads/main.zip"
+          # twine has no release for 3.13, yet, see https://github.com/pypa/twine/issues/1030
+          pip install -U "git+https://github.com/pypa/twine.git#egg=twine"
+{% endif %}
       - name: Install Build Dependencies
+{% if with_future_python %}
+        if: matrix.python-version != '%(future_python_version)s'
+{% endif %}
         run: |
           pip install -U pip
           pip install -U setuptools wheel twine cffi
@@ -241,6 +256,9 @@ jobs:
         if: ${{ startsWith(matrix.python-version, '%(future_python_version)s') }}
         run: |
           pip install -U wheel setuptools
+          # cffi will probably have no public release until a beta or even RC
+          # version of Python 3.13, see https://github.com/python-cffi/cffi/issues/23
+          pip install -U 'cffi @ https://github.com/python-cffi/cffi/archive/refs/heads/main.zip ; platform_python_implementation == "CPython"'
           # coverage has a wheel on PyPI for a future python version which is
           # not ABI compatible with the current one, so build it from sdist:
           pip install -U --no-binary :all: coverage


### PR DESCRIPTION
Used in https://github.com/zopefoundation/persistent/pull/188