### PR TITLE
Update GitHub cache action to version 4

### DIFF
--- a/config/c-code/tests-cache.j2
+++ b/config/c-code/tests-cache.j2
@@ -16,7 +16,7 @@
           echo "dir=$(pip cache dir)" >>$GITHUB_OUTPUT
 
       - name: pip cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: %(cache_key)s

--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -105,7 +105,7 @@ jobs:
       with:
         python-version: ${{ matrix.config[0] }}
     - name: Pip cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}


### PR DESCRIPTION
This prevents deprecation warnings on the Actions output