### PR TITLE
Prevent non-standard interpreters in manylinux builds

### DIFF
--- a/config/c-code/manylinux-install.sh.j2
+++ b/config/c-code/manylinux-install.sh.j2
@@ -46,16 +46,16 @@ tox_env_map() {
 for PYBIN in /opt/python/*/bin; do
     if \
 {% if with_future_python %}
-       [[ "${PYBIN}" == *"cp313"* ]] || \
+       [[ "${PYBIN}" == *"cp313/"* ]] || \
 {% endif %}
-       [[ "${PYBIN}" == *"cp311"* ]] || \
-       [[ "${PYBIN}" == *"cp312"* ]] || \
-       [[ "${PYBIN}" == *"cp37"* ]] || \
-       [[ "${PYBIN}" == *"cp38"* ]] || \
-       [[ "${PYBIN}" == *"cp39"* ]] || \
-       [[ "${PYBIN}" == *"cp310"* ]] ; then
+       [[ "${PYBIN}" == *"cp311/"* ]] || \
+       [[ "${PYBIN}" == *"cp312/"* ]] || \
+       [[ "${PYBIN}" == *"cp37/"* ]] || \
+       [[ "${PYBIN}" == *"cp38/"* ]] || \
+       [[ "${PYBIN}" == *"cp39/"* ]] || \
+       [[ "${PYBIN}" == *"cp310/"* ]] ; then
 {% if with_future_python %}
-        if [[ "${PYBIN}" == *"cp313"* ]] ; then
+        if [[ "${PYBIN}" == *"cp313/"* ]] ; then
             "${PYBIN}/pip" install --pre -e /io/
             "${PYBIN}/pip" wheel /io/ --pre -w wheelhouse/
         else


### PR DESCRIPTION
Fixes #240 

This change prevents attempts to build a package and run tests on it for non-standard interpreters like the Python 3.13 no-GIL build in the manylinux aarch64 environment.

Tested successfully at https://github.com/zopefoundation/zope.interface/actions/runs/9202742557
