### PR TITLE
Pin setuptools again

### DIFF
--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -101,7 +101,7 @@ jobs:
         if: matrix.python-version == '%(future_python_version)s'
         run: |
           pip install -U pip
-          pip install -U setuptools wheel twine
+          pip install -U "setuptools<69" wheel twine
   {% if require_cffi %}
           # Remove this hack once 'cffi' has a release supporting Python 3.13.
           pip install -e "git+https://github.com/python-cffi/cffi.git#egg=cffi"
@@ -113,7 +113,7 @@ jobs:
 {% endif %}
         run: |
           pip install -U pip
-          pip install -U setuptools wheel twine
+          pip install -U "setuptools<69" wheel twine
   {% if require_cffi %}
           pip install cffi
   {% endif %}
@@ -257,7 +257,7 @@ jobs:
       - name: Install %(package_name)s %(future_python_version)s ${{ matrix.python-version }}
         if: matrix.python-version == '%(future_python_version)s'
         run: |
-          pip install -U wheel setuptools
+          pip install -U wheel "setuptools<69"
   {% if require_cffi %}
           # Remove this hack once 'cffi' has a release supporting Python 3.13.
           pip install -e "git+https://github.com/python-cffi/cffi.git#egg=cffi"
@@ -278,7 +278,7 @@ jobs:
         if: matrix.python-version != '%(future_python_version)s'
 {% endif %}
         run: |
-          pip install -U wheel setuptools
+          pip install -U wheel "setuptools<69"
           pip install -U coverage
           pip install -U 'cffi; platform_python_implementation == "CPython"'
           # Unzip into src/ so that testrunner can find the .so files

--- a/config/default/tox-testenv.j2
+++ b/config/default/tox-testenv.j2
@@ -9,6 +9,7 @@ wheel_build_env = .pkg
 pip_pre = py313: true
 {% endif %}
 deps =
+  setuptools < 69
   {% for line in testenv_deps %}
     %(line)s
   {% endfor %}


### PR DESCRIPTION
Pin setuptools so...

- source distributions don't get dotted names replaced by underscores
- zc.buildout compatibility issues