### PR TITLE
Add an explicit PyPI upload step for Windows

### DIFF
--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -223,29 +223,14 @@ jobs:
           path: dist/*whl
   {% endif %}
 {% endfor %}
-      - name: Publish package to PyPI (Windows)
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish package to PyPI (Non-Linux)
+        # We cannot use pypa/gh-action-pypi-publish because that
+        # is a container action, and those don't run on macOS
+        # or Windows GHA runners.
         if: >
           github.event_name == 'push'
           && startsWith(github.ref, 'refs/tags')
-          && startsWith(runner.os, 'Windows')
-          && !startsWith(matrix.python-version, 'pypy')
-{% if with_future_python %}
-          && !startsWith(matrix.python-version, '%(future_python_version)s')
-{% endif %}
-        with:
-          user: __token__
-          password: ${{ secrets.TWINE_PASSWORD }}
-          skip-existing: true
-          packages-dir: dist/
-      - name: Publish package to PyPI (mac)
-        # We cannot 'uses: pypa/gh-action-pypi-publish@v1.4.1' because
-        # that's apparently a container action, and those don't run on
-        # the Mac.
-        if: >
-          github.event_name == 'push'
-          && startsWith(github.ref, 'refs/tags')
-          && startsWith(runner.os, 'Mac')
+          && !startsWith(runner.os, 'Linux')
           && !startsWith(matrix.python-version, 'pypy')
 {% if with_future_python %}
           && !startsWith(matrix.python-version, '%(future_python_version)s')

--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -223,6 +223,21 @@ jobs:
           path: dist/*whl
   {% endif %}
 {% endfor %}
+      - name: Publish package to PyPI (Windows)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: >
+          github.event_name == 'push'
+          && startsWith(github.ref, 'refs/tags')
+          && startsWith(runner.os, 'Windows')
+          && !startsWith(matrix.python-version, 'pypy')
+{% if with_future_python %}
+          && !startsWith(matrix.python-version, '%(future_python_version)s')
+{% endif %}
+        with:
+          user: __token__
+          password: ${{ secrets.TWINE_PASSWORD }}
+          skip-existing: true
+          packages-dir: dist/
       - name: Publish package to PyPI (mac)
         # We cannot 'uses: pypa/gh-action-pypi-publish@v1.4.1' because
         # that's apparently a container action, and those don't run on
@@ -435,5 +450,5 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.TWINE_PASSWORD }}
-          skip_existing: true
-          packages_dir: wheelhouse/
+          skip-existing: true
+          packages-dir: wheelhouse/


### PR DESCRIPTION
A step for uploading the Windows wheels built on GitHub was missing. See https://github.com/zopefoundation/zope.interface/pull/296

