### PR TITLE
Lint using tox

### DIFF
--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -373,12 +373,9 @@ jobs:
           pip install -U wheel
           pip install -U `ls dist/%(package_name)s-*`[test]
       - name: Lint
-        # We only need to do this on one version, and it should be Python 3, because
-        # pylint has stopped updating for Python 2.
-        # TODO: Pick a linter and configuration and make this step right.
         run: |
-          pip install -U pylint
-          # python -m pylint --limit-inference-results=1 --rcfile=.pylintrc %(package_name)s -f parseable -r n
+          pip install -U tox
+          tox -e lint
 
   manylinux:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The c-code template had a broken linting step that did nothing and wanted to use pylint. Switch to using tox instead so the linting with tox locally and the linting on GHA deliver the same results.