### PR TITLE
Use new cffi prerelease

### DIFF
--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -101,10 +101,10 @@ jobs:
         if: matrix.python-version == '%(future_python_version)s'
         run: |
           pip install -U pip
-          pip install -U "setuptools<69" wheel twine
   {% if require_cffi %}
-          pip install --pre cffi
+          pip install -U --pre cffi
   {% endif %}
+          pip install -U "setuptools<69" wheel twine
 {% endif %}
       - name: Install Build Dependencies
 {% if with_future_python %}
@@ -248,10 +248,10 @@ jobs:
       - name: Install %(package_name)s ${{ matrix.python-version }}
         if: matrix.python-version == '%(future_python_version)s'
         run: |
-          pip install -U wheel "setuptools<69"
   {% if require_cffi %}
-          pip install --pre cffi
+          pip install -U --pre cffi
   {%  endif %}
+          pip install -U wheel "setuptools<69"
           # coverage might have a wheel on PyPI for a future python version which is
           # not ABI compatible with the current one, so build it from sdist:
           pip install -U --no-binary :all: coverage

--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -103,8 +103,7 @@ jobs:
           pip install -U pip
           pip install -U "setuptools<69" wheel twine
   {% if require_cffi %}
-          # Remove this hack once 'cffi' has a release supporting Python 3.13.
-          pip install -e "git+https://github.com/python-cffi/cffi.git#egg=cffi"
+          pip install --pre cffi
   {% endif %}
 {% endif %}
       - name: Install Build Dependencies
@@ -246,13 +245,12 @@ jobs:
   {% endfor %}
 {% else %}
 {% if with_future_python %}
-      - name: Install %(package_name)s %(future_python_version)s ${{ matrix.python-version }}
+      - name: Install %(package_name)s ${{ matrix.python-version }}
         if: matrix.python-version == '%(future_python_version)s'
         run: |
           pip install -U wheel "setuptools<69"
   {% if require_cffi %}
-          # Remove this hack once 'cffi' has a release supporting Python 3.13.
-          pip install -e "git+https://github.com/python-cffi/cffi.git#egg=cffi"
+          pip install --pre cffi
   {%  endif %}
           # coverage might have a wheel on PyPI for a future python version which is
           # not ABI compatible with the current one, so build it from sdist:

--- a/config/set_branch_protection_rules.py
+++ b/config/set_branch_protection_rules.py
@@ -74,7 +74,7 @@ def set_branch_protection(repo: str, meta_path: pathlib.Path | None) -> bool:
             f'manylinux ({MANYLINUX_PYTHON_VERSION}, {MANYLINUX_I686})',
             f'manylinux ({MANYLINUX_PYTHON_VERSION}, {MANYLINUX_X86_64})',
             f'lint ({MANYLINUX_PYTHON_VERSION}, ubuntu-latest)',
-            f'test ({OLDEST_PYTHON_VERSION}, macos-12)',
+            f'test ({OLDEST_PYTHON_VERSION}, macos-latest)',
             f'test ({NEWEST_PYTHON_VERSION}, macos-latest)',
             f'test ({OLDEST_PYTHON_VERSION}, ubuntu-latest)',
             f'test ({NEWEST_PYTHON_VERSION}, ubuntu-latest)',


### PR DESCRIPTION
... and fix the macOS version for Python 3.8 tests branch protection rule.