### PR TITLE
Prevent publishing wheels for unreleased Python versions

### DIFF
--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -416,7 +416,6 @@ jobs:
         run: sudo chown -R $(whoami) ${{ steps.pip-cache-default.outputs.dir }}
 {% if with_future_python %}
       - name: Prevent publishing wheels for unreleased Python versions
-        if: '%(future_python_version)s' != ''
         run: VER=$(echo '%(future_python_version)s' | tr -d .) && rm -f wheelhouse/*-cp${VER}*.whl
 {% endif %}
       - name: Publish package to PyPI

--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -414,6 +414,11 @@ jobs:
           name: manylinux_${{ matrix.image }}_wheels.zip
       - name: Restore pip cache permissions
         run: sudo chown -R $(whoami) ${{ steps.pip-cache-default.outputs.dir }}
+{% if with_future_python %}
+      - name: Prevent publishing wheels for unreleased Python versions
+        if: '%(future_python_version)s' != ''
+        run: VER=$(echo '%(future_python_version)s' | tr -d .) && rm -f wheelhouse/*-cp${VER}*.whl
+{% endif %}
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         if: >


### PR DESCRIPTION
This change tries to prevent publishing wheels for future_python versions during the `manylinux` GHA step.