### PR TITLE
Set with_future_python to false if no future python version is defined

### DIFF
--- a/config/config-package.py
+++ b/config/config-package.py
@@ -229,9 +229,12 @@ class PackageConfiguration:
 
     @cached_property
     def with_future_python(self):
+        value = self._set_python_config_value('future-python')
+
         if not FUTURE_PYTHON_VERSION:
             return 'false'
-        return self._set_python_config_value('future-python')
+
+        return value
 
     @cached_property
     def with_docs(self):

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -229,6 +229,8 @@ class PackageConfiguration:
 
     @cached_property
     def with_future_python(self):
+        if not FUTURE_PYTHON_VERSION:
+            return 'false'
         return self._set_python_config_value('future-python')
 
     @cached_property


### PR DESCRIPTION
This change overrides the value for `with_future_python` and sets it to `false` if there is no future Python version defined.

The goal is to "turn off" the flag with just a change in meta/config itself instead of having to touch all package configurations. So when a new Python version is released and no suitable next Python alpha/beta is available on GHA all you need to do is to set `shared.packages.FUTURE_PYTHON_VERSION` to an empty string and add the new Python release version to the various templates before re-running for a given package. The package won't need any changes itself. Once a new alpha/beta is on GHA that version number can be set again and the packages that do define `with_future_python` will pick it up the next time meta/config is run on them.