### PR TITLE
Add script to update to currently supported Python versions.

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -658,6 +658,22 @@ Hints
 * Call ``bin/check-python-versions <path-to-package> -h`` to see how to fix
   version mismatches in the *lint* tox environment.
 
+Updating to the currently supported Python versions
+---------------------------------------------------
+
+There is `update-python-support.py` which can be used to update a repository to
+the currently supported Python versions as defined in ``shared/package.py``.
+
+Usage
++++++
+
+To update a repository to the currently supported Python versions call::
+
+    $ bin/python update-python-support.py <path-to-package>
+
+It supports a parameter ``--interactive`` to not automatically commiting the
+changes.
+
 
 Calling a script on multiple repositories
 -----------------------------------------

--- a/config/README.rst
+++ b/config/README.rst
@@ -671,8 +671,11 @@ To update a repository to the currently supported Python versions call::
 
     $ bin/python update-python-support.py <path-to-package>
 
-It supports a parameter ``--interactive`` to not automatically commiting the
-changes.
+It supports a parameter ``--interactive`` to gather user input for its changes
+and not automatically commit them. It also supports a parameter ``--no-commit``
+that prevents automatic commits but attempts to cut down on interactively
+asking for user input. Some of that still happens due to limitations
+of the ``zest.releaser`` scripts used by ``update-python-support.py``.
 
 
 Calling a script on multiple repositories

--- a/config/default/tox-lint.j2
+++ b/config/default/tox-lint.j2
@@ -1,3 +1,4 @@
+
 {% include 'tox-release-check.j2' %}
 
 [testenv:lint]

--- a/config/shared/packages.py
+++ b/config/shared/packages.py
@@ -19,6 +19,10 @@ ORG = 'zopefoundation'
 BASE_PATH = pathlib.Path(__file__).parent.parent
 OLDEST_PYTHON_VERSION = '3.8'
 NEWEST_PYTHON_VERSION = '3.12'
+SUPPORTED_PYTHON_VERSIONS = [
+    f'3.{i}' for i in range(int(OLDEST_PYTHON_VERSION.replace('3.', '')),
+                            int(NEWEST_PYTHON_VERSION.replace('3.', '')) + 1)
+]
 FUTURE_PYTHON_VERSION = '3.13'
 PYPY_VERSION = '3.10'
 MANYLINUX_PYTHON_VERSION = '3.11'
@@ -33,12 +37,9 @@ def list_packages(path: pathlib.Path) -> list:
     ``path`` must point to a packages.txt file.
     """
     return [
-        p
-        for p in path.read_text().split('\n')
-        if p and not p.startswith('#')
+        p for p in path.read_text().split('\n') if p and not p.startswith('#')
     ]
 
 
 ALL_REPOS = itertools.chain(
-    *[list_packages(BASE_PATH / type / 'packages.txt')
-      for type in TYPES])
+    *[list_packages(BASE_PATH / type / 'packages.txt') for type in TYPES])

--- a/config/update-python-support.py
+++ b/config/update-python-support.py
@@ -15,9 +15,12 @@ from shared.call import call
 from shared.call import wait_for_accept
 from shared.git import get_branch_name
 from shared.git import git_branch
+from shared.packages import OLDEST_PYTHON_VERSION
+from shared.packages import SUPPORTED_PYTHON_VERSIONS
 from shared.path import change_dir
 import argparse
 import collections
+import configparser
 import os
 import pathlib
 import shutil
@@ -25,8 +28,20 @@ import sys
 import tomlkit
 
 
+def get_tox_ini_python_versions(path):
+    config = configparser.ConfigParser()
+    config.read(path)
+    envs = config['tox']['envlist'].split()
+    versions = [
+        env.replace('py', '').replace('3', '3.') for env in envs
+        if env.startswith('py') and env != 'pypy3'
+    ]
+    return versions
+
+
 parser = argparse.ArgumentParser(
-    description='Drop support of Python 3.7 from a package.')
+    description='Update Python versions of a package to currently supported'
+    ' ones.')
 parser.add_argument('path',
                     type=pathlib.Path,
                     help='path to the repository to be configured')
@@ -57,21 +72,36 @@ with change_dir(path) as cwd_str:
     cwd = pathlib.Path(cwd_str)
     bin_dir = cwd / 'bin'
     with open('.meta.toml', 'rb') as meta_f:
-        meta_cfg = collections.defaultdict(dict, **tomlkit.load(meta_f))
-    config_type = meta_cfg['meta']['template']
+        meta_toml = collections.defaultdict(dict, **tomlkit.load(meta_f))
+    config_type = meta_toml['meta']['template']
     branch_name = get_branch_name(args.branch_name, config_type)
     updating = git_branch(branch_name)
 
+    current_python_versions = get_tox_ini_python_versions('tox.ini')
+    no_longer_supported = (set(current_python_versions) -
+                           set(SUPPORTED_PYTHON_VERSIONS))
+    not_yet_supported = (set(SUPPORTED_PYTHON_VERSIONS) -
+                         set(current_python_versions))
+
     if not args.interactive:
-        call(bin_dir / 'bumpversion', '--breaking', '--no-input')
-        call(bin_dir / 'addchangelogentry', 'Drop support for Python 3.7.',
-             '--no-input')
-    else:
-        call(bin_dir / 'bumpversion', '--breaking')
-        call(bin_dir / 'addchangelogentry', 'Drop support for Python 3.7.')
-    call(bin_dir / 'check-python-versions', '--drop=2.7,3.5,3.6,3.7',
-         '--only=setup.py')
-    print('Remove legacy Python specific settings from .meta.toml')
+        non_interactive_params = ['--no-input']
+    if no_longer_supported or not_yet_supported:
+        call(bin_dir / 'bumpversion', '--feature', *non_interactive_params)
+    python_versions_args = ['--add=' + ','.join(SUPPORTED_PYTHON_VERSIONS)]
+    if no_longer_supported:
+        for version in sorted(list(no_longer_supported)):
+            call(bin_dir / 'addchangelogentry',
+                 f'Drop support for Python {version}.',
+                 *non_interactive_params)
+        python_versions_args.append('--drop=' + ','.join(no_longer_supported))
+    if not_yet_supported:
+        for version in sorted(list(not_yet_supported)):
+            call(bin_dir / 'addchangelogentry',
+                 f'Add support for Python {version}.', *non_interactive_params)
+
+    call(bin_dir / 'check-python-versions', '--only=setup.py',
+         *python_versions_args)
+    print('Look trough .meta.toml to see if it needs changes.')
     call(os.environ['EDITOR'], '.meta.toml')
 
     config_package_args = [
@@ -85,11 +115,12 @@ with change_dir(path) as cwd_str:
         config_package_args.append('--no-commit')
     call(*config_package_args, cwd=cwd_str)
     src = path.resolve() / 'src'
+    py_version_plus = f'--py{OLDEST_PYTHON_VERSION.replace(".", "")}-plus'
     call('find', src, '-name', '*.py', '-exec', bin_dir / 'pyupgrade',
-         '--py3-plus', '--py38-plus', '{}', ';')
+         '--py3-plus', py_version_plus, '{}', ';')
     call(bin_dir / 'pyupgrade',
          '--py3-plus',
-         '--py38-plus',
+         py_version_plus,
          'setup.py',
          allowed_return_codes=(0, 1))
 
@@ -97,8 +128,8 @@ with change_dir(path) as cwd_str:
                 '--exclude', '*.pyc', '--exclude', '*.so')
     print('Replace any remaining code that might support legacy Python:')
     call('egrep',
-         '-rn',
-         '3.7|sys.version|PY3|Py3|Python 3|__unicode__|ImportError',
+         '-rn', f'{"|".join(no_longer_supported)}|sys.version|PY3|Py3|Python 3'
+         '|__unicode__|ImportError',
          src,
          *excludes,
          allowed_return_codes=(0, 1))
@@ -108,7 +139,7 @@ with change_dir(path) as cwd_str:
     if not args.interactive:
         print('Adding, committing and pushing all changes ...')
         call('git', 'add', '.')
-        call('git', 'commit', '-m', 'Drop support for Python 3.7.')
+        call('git', 'commit', '-m', 'Update Python version support.')
         call('git', 'push', '--set-upstream', 'origin', branch_name)
         if updating:
             print('Updated the previously created PR.')

--- a/config/update-python-support.py
+++ b/config/update-python-support.py
@@ -85,6 +85,8 @@ with change_dir(path) as cwd_str:
 
     if not args.interactive:
         non_interactive_params = ['--no-input']
+    else:
+        non_interactive_params = []
     if no_longer_supported or not_yet_supported:
         call(bin_dir / 'bumpversion', '--feature', *non_interactive_params)
     python_versions_args = ['--add=' + ','.join(SUPPORTED_PYTHON_VERSIONS)]


### PR DESCRIPTION
Remove previous script to drop support for old Python versions instead.

The script is now able to drop and add in one go and does not need to be adapted for version updates in the range of supported versions.

See https://github.com/zopefoundation/z3c.currency/pull/8 which was built using this PR.