### PR TITLE
fix: disable 'usedevelop' when testing projects with C extensions

### DIFF
--- a/config/default/tox-testenv.j2
+++ b/config/default/tox-testenv.j2
@@ -1,6 +1,8 @@
 
 [testenv]
+{% if config_type != 'c-code' %}
 usedevelop = true
+{% endif %}
 {% if config_type == "pure-python" %}
 package = wheel
 wheel_build_env = .pkg


### PR DESCRIPTION
Closes #256.