### PR TITLE
chore: rationalize config option names

### DIFF
--- a/config/buildout-recipe/coveragerc.j2
+++ b/config/buildout-recipe/coveragerc.j2
@@ -2,7 +2,7 @@
 source = %(coverage_run_source)s
 branch = true
 parallel = true
-{% for line in run_additional_config %}
+{% for line in coverage_run_additional_config %}
 %(line)s
 {% endfor %}
 

--- a/config/buildout-recipe/tox.ini.j2
+++ b/config/buildout-recipe/tox.ini.j2
@@ -36,7 +36,7 @@ commands =
 {% endif %}
     coverage combine
     coverage html
-    coverage report -m --fail-under=%(fail_under)s
+    coverage report -m --fail-under=%(coverage_fail_under)s
 {% for line in coverage_additional %}
 %(line)s
 {% endfor %}

--- a/config/c-code/coveragerc.j2
+++ b/config/c-code/coveragerc.j2
@@ -3,7 +3,7 @@ source = %(coverage_run_source)s
 # New in 5.0; required for the GHA coveralls submission.
 relative_files = True
 branch = true
-{% for line in run_additional_config %}
+{% for line in coverage_run_additional_config %}
 %(line)s
 {% endfor %}
 

--- a/config/c-code/manylinux-install.sh.j2
+++ b/config/c-code/manylinux-install.sh.j2
@@ -21,7 +21,7 @@ fi
 ls -ld /cache
 ls -ld /cache/pip
 
-{% for line in setup %}
+{% for line in manylinux_install_setup %}
 %(line)s
 {% endfor %}
 # We need some libraries because we build wheels from scratch:
@@ -65,7 +65,7 @@ for PYBIN in /opt/python/*/bin; do
         "${PYBIN}/pip" wheel /io/ -w wheelhouse/
 {% endif %}
         if [ `uname -m` == 'aarch64' ]; then
-{% for line in aarch64_tests %}
+{% for line in manylinux_aarch64_tests %}
           %(line)s
 {% endfor %}
         fi

--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -116,8 +116,8 @@ jobs:
   {% if require_cffi %}
           pip install cffi
   {% endif %}
-{% if gha_additional_build_dependencies %}
-  {% for line in gha_additional_build_dependencies %}
+{% if gha_additional_build_deps %}
+  {% for line in gha_additional_build_deps %}
           pip install -U %(line)s
   {% endfor %}
 {% endif %}

--- a/config/c-code/tox.ini.j2
+++ b/config/c-code/tox.ini.j2
@@ -51,7 +51,7 @@ commands =
     coverage run -m zope.testrunner --test-path=src {posargs:-vc}
 {% endif %}
     coverage html -i
-    coverage report -i -m --fail-under=%(fail_under)s
+    coverage report -i -m --fail-under=%(coverage_fail_under)s
 {% for line in coverage_additional %}
 %(line)s
 {% endfor %}

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -249,7 +249,7 @@ class PackageConfiguration:
         return self.meta_cfg['coverage-run'].get('source', self.path.name)
 
     @cached_property
-    def fail_under(self):
+    def coverage_fail_under(self):
         return self.meta_cfg['coverage'].setdefault('fail-under', 0)
 
     @cached_property
@@ -315,8 +315,8 @@ class PackageConfiguration:
             'setup.cfg.j2',
             self.path / 'setup.cfg',
             self.config_type,
-            additional_flake8_config=extra_flake8_config,
-            additional_check_manifest_ignores=extra_check_manifest_ignores,
+            flake8_additional_config=extra_flake8_config,
+            check_manifest_additional_ignores=extra_check_manifest_ignores,
             check_manifest_ignore_bad_ideas=check_manifest_ignore_bad_ideas,
             isort_known_third_party=isort_known_third_party,
             isort_known_zope=isort_known_zope,
@@ -333,17 +333,17 @@ class PackageConfiguration:
         self.copy_with_meta(
             'gitignore.j2', self.path / '.gitignore',
             self.config_type,
-            ignore=git_ignore,
+            git_ignore=git_ignore,
         )
 
     def readthedocs(self):
-        build_extra = self.cfg_option(
+        rtd_build_extra = self.cfg_option(
             'readthedocs', 'build-extra', default=[])
         self.copy_with_meta(
             'readthedocs.yaml.j2',
             self.path / '.readthedocs.yaml',
             self.config_type,
-            build_extra=build_extra,
+            rtd_build_extra=rtd_build_extra,
         )
 
     def coveragerc(self):
@@ -355,7 +355,7 @@ class PackageConfiguration:
                 self.path / '.coveragerc',
                 self.config_type,
                 coverage_run_source=self.coverage_run_source,
-                run_additional_config=coverage_run_additional_config,
+                coverage_run_additional_config=coverage_run_additional_config,
             )
             self.add_coveragerc = True
         elif (self.path / '.coveragerc').exists():
@@ -382,8 +382,8 @@ class PackageConfiguration:
                 'manylinux-install.sh.j2', self.path / '.manylinux-install.sh',
                 self.config_type,
                 package_name=self.path.name,
-                setup=manylinux_install_setup,
-                aarch64_tests=manylinux_aarch64_tests,
+                manylinux_install_setup=manylinux_install_setup,
+                manylinux_aarch64_tests=manylinux_aarch64_tests,
                 with_future_python=self.with_future_python,
             )
             (self.path / '.manylinux-install.sh').chmod(0o755)
@@ -443,11 +443,11 @@ class PackageConfiguration:
             # if no additional sources are provided:
             isort_additional_sources = f' {isort_additional_sources}'
         if self.args.use_flake8 is None:
-            use_flake8 = self.tox_option('use-flake8', default=True)
+            tox_use_flake8 = self.tox_option('use-flake8', default=True)
         else:
-            use_flake8 = self.args.use_flake8
+            tox_use_flake8 = self.args.use_flake8
         docs_deps = self.tox_option('docs-deps', default=[])
-        self.meta_cfg['tox']['use-flake8'] = use_flake8
+        self.meta_cfg['tox']['use-flake8'] = tox_use_flake8
         self.copy_with_meta(
             'tox.ini.j2',
             self.path / 'tox.ini',
@@ -459,7 +459,7 @@ class PackageConfiguration:
             coverage_run_source=self.coverage_run_source,
             coverage_run_additional_config=coverage_run_additional_config,
             coverage_setenv=coverage_setenv,
-            fail_under=self.fail_under,
+            coverage_fail_under=self.coverage_fail_under,
             flake8_additional_sources=flake8_additional_sources,
             flake8_additional_plugins=flake8_additional_plugins,
             isort_additional_sources=isort_additional_sources,
@@ -469,7 +469,7 @@ class PackageConfiguration:
             testenv_commands_pre=testenv_commands_pre,
             testenv_deps=testenv_deps,
             testenv_setenv=testenv_setenv,
-            use_flake8=use_flake8,
+            tox_use_flake8=tox_use_flake8,
             with_docs=self.with_docs,
             with_future_python=self.with_future_python,
             with_pypy=self.with_pypy,
@@ -481,30 +481,31 @@ class PackageConfiguration:
         workflows = self.path / '.github' / 'workflows'
         workflows.mkdir(parents=True, exist_ok=True)
 
-        services = self.gh_option('services')
-        additional_config = self.gh_option('additional-config')
-        additional_exclude = self.gh_option('additional-exclude')
-        steps_before_checkout = self.gh_option('steps-before-checkout')
-        additional_install = self.gh_option('additional-install')
-        additional_build_dependencies = self.gh_option(
+        gha_services = self.gh_option('services')
+        gha_additional_config = self.gh_option('additional-config')
+        gha_additional_exclude = self.gh_option('additional-exclude')
+        gha_steps_before_checkout = self.gh_option('steps-before-checkout')
+        gha_additional_install = self.gh_option('additional-install')
+        gha_additional_build_dependencies = self.gh_option(
             'additional-build-dependencies')
-        test_environment = self.gh_option('test-environment')
-        test_commands = self.gh_option('test-commands')
+        gha_test_environment = self.gh_option('test-environment')
+        gha_test_commands = self.gh_option('test-commands')
         require_cffi = self.meta_cfg.get(
             'c-code', {}).get('require-cffi', False)
         self.copy_with_meta(
             'tests.yml.j2',
             workflows / 'tests.yml',
             self.config_type,
-            gha_additional_config=additional_config,
-            gha_additional_exclude=additional_exclude,
-            gha_additional_install=additional_install,
-            gha_additional_build_dependencies=additional_build_dependencies,
-            gha_test_environment=test_environment,
-            gha_test_commands=test_commands,
             package_name=self.path.name,
-            services=services,
-            steps_before_checkout=steps_before_checkout,
+            gha_additional_config=gha_additional_config,
+            gha_additional_exclude=gha_additional_exclude,
+            gha_additional_install=gha_additional_install,
+            gha_additional_build_dependencies=
+                gha_additional_build_dependencies,
+            gha_test_environment=gha_test_environment,
+            gha_test_commands=gha_test_commands,
+            gha_services=gha_services,
+            gha_steps_before_checkout=gha_steps_before_checkout,
             with_docs=self.with_docs,
             with_sphinx_doctests=self.with_sphinx_doctests,
             with_future_python=self.with_future_python,
@@ -522,18 +523,18 @@ class PackageConfiguration:
 
     def manifest_in(self):
         """Modify MANIFEST.in with meta options."""
-        additional_manifest_rules = self.meta_cfg['manifest'].get(
+        manifest_additional_rules = self.meta_cfg['manifest'].get(
             'additional-rules', [])
         if (self.with_docs and 'include *.yaml'
-                not in additional_manifest_rules):
-            additional_manifest_rules.insert(0, 'include *.yaml')
+                not in manifest_additional_rules):
+            manifest_additional_rules.insert(0, 'include *.yaml')
         if self.config_type == 'c-code' \
-                and 'include *.sh' not in additional_manifest_rules:
-            additional_manifest_rules.insert(0, 'include *.sh')
+                and 'include *.sh' not in manifest_additional_rules:
+            manifest_additional_rules.insert(0, 'include *.sh')
         if self.config_type != 'toolkit':
             self.copy_with_meta(
                 'MANIFEST.in.j2', self.path / 'MANIFEST.in', self.config_type,
-                additional_rules=additional_manifest_rules,
+                manifest_additional_rules=manifest_additional_rules,
                 with_docs=self.with_docs)
 
     def copy_with_meta(
@@ -614,7 +615,7 @@ class PackageConfiguration:
 
             updating = git_branch(self.branch_name)
 
-            if not self.fail_under:
+            if not self.coverage_fail_under:
                 print(
                     'In .meta.toml in section [coverage] the option '
                     '"fail-under" is  0. Please enter a valid minimum '

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -486,7 +486,7 @@ class PackageConfiguration:
         gha_additional_exclude = self.gh_option('additional-exclude')
         gha_steps_before_checkout = self.gh_option('steps-before-checkout')
         gha_additional_install = self.gh_option('additional-install')
-        gha_additional_build_dependencies = self.gh_option(
+        gha_additional_build_deps = self.gh_option(
             'additional-build-dependencies')
         gha_test_environment = self.gh_option('test-environment')
         gha_test_commands = self.gh_option('test-commands')
@@ -500,8 +500,7 @@ class PackageConfiguration:
             gha_additional_config=gha_additional_config,
             gha_additional_exclude=gha_additional_exclude,
             gha_additional_install=gha_additional_install,
-            gha_additional_build_dependencies=
-                gha_additional_build_dependencies,
+            gha_additional_build_deps=gha_additional_build_deps,
             gha_test_environment=gha_test_environment,
             gha_test_commands=gha_test_commands,
             gha_services=gha_services,

--- a/config/default/MANIFEST.in.j2
+++ b/config/default/MANIFEST.in.j2
@@ -15,6 +15,6 @@ recursive-include docs Makefile
 {% endif %}
 
 recursive-include src *.py
-{% for line in additional_rules %}
+{% for line in manifest_additional_rules %}
 %(line)s
 {% endfor %}

--- a/config/default/gitignore.j2
+++ b/config/default/gitignore.j2
@@ -28,6 +28,6 @@ parts/
 pyvenv.cfg
 testing.log
 var/
-{% for line in ignore %}
+{% for line in git_ignore %}
 %(line)s
 {% endfor %}

--- a/config/default/readthedocs.yaml.j2
+++ b/config/default/readthedocs.yaml.j2
@@ -9,8 +9,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-{% if build_extra %}
-  {% for line in build_extra %}
+{% if rtd_build_extra %}
+  {% for line in rtd_build_extra %}
   %(line)s
   {% endfor %}
 {% endif %}

--- a/config/default/setup.cfg.j2
+++ b/config/default/setup.cfg.j2
@@ -16,7 +16,7 @@ builtins = write, system, cat, join
 no-accept-encodings = True
 htmldir = parts/flake8
 {% endif %}
-{% for line in additional_flake8_config %}
+{% for line in flake8_additional_config %}
 %(line)s
 {% endfor %}
 
@@ -30,7 +30,7 @@ ignore =
 {% if with_sphinx_doctests %}
     docs/_build/doctest/*
 {% endif %}
-{% for line in additional_check_manifest_ignores %}
+{% for line in check_manifest_additional_ignores %}
     %(line)s
 {% endfor %}
 {% if check_manifest_ignore_bad_ideas %}

--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -15,9 +15,9 @@ on:
 
 jobs:
   build:
-{% if services %}
+{% if gha_services %}
     services:
-{% for line in services %}
+{% for line in gha_services %}
       %(line)s
 {% endfor %}
 {% endif %}
@@ -88,7 +88,7 @@ jobs:
     name: ${{ matrix.config[1] }}
 {% endif %}
     steps:
-{% for line in steps_before_checkout %}
+{% for line in gha_steps_before_checkout %}
     %(line)s
 {% endfor %}
     - uses: actions/checkout@v4

--- a/config/default/tox-lint.j2
+++ b/config/default/tox-lint.j2
@@ -6,7 +6,7 @@ basepython = python3
 skip_install = true
 deps =
     isort
-{% if use_flake8 %}
+{% if tox_use_flake8 %}
     flake8
 {% for line in flake8_additional_plugins %}
     %(line)s
@@ -14,7 +14,7 @@ deps =
 {% endif %}
 commands =
     isort --check-only --diff {toxinidir}/src {toxinidir}/setup.py%(isort_additional_sources)s
-{% if use_flake8 %}
+{% if tox_use_flake8 %}
     flake8 src setup.py%(flake8_additional_sources)s
 {% endif %}
 

--- a/config/pure-python/tox.ini.j2
+++ b/config/pure-python/tox.ini.j2
@@ -35,7 +35,7 @@ commands =
     coverage run -a -m sphinx -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
 {% endif %}
     coverage html --ignore-errors
-    coverage report --show-missing --fail-under=%(fail_under)s
+    coverage report --show-missing --fail-under=%(coverage_fail_under)s
 {% for line in coverage_additional %}
 %(line)s
 {% endfor %}

--- a/config/toolkit/tox.ini.j2
+++ b/config/toolkit/tox.ini.j2
@@ -41,18 +41,18 @@ commands =
 [testenv:lint]
 basepython = python3
 commands_pre =
-{% if use_flake8 %}
+{% if tox_use_flake8 %}
     mkdir -p {toxinidir}/parts/flake8
 allowlist_externals =
     mkdir
 {% endif %}
 commands =
-{% if use_flake8 %}
+{% if tox_use_flake8 %}
     isort --check-only --diff {toxinidir}/docs%(isort_additional_sources)s
     flake8 {toxinidir}/docs%(flake8_additional_sources)s
 {% endif %}
 deps =
-{% if use_flake8 %}
+{% if tox_use_flake8 %}
     flake8
     isort
 {% include 'tox-release-check.j2' %}

--- a/config/zope-product/tox.ini.j2
+++ b/config/zope-product/tox.ini.j2
@@ -43,18 +43,18 @@ commands =
 [testenv:lint]
 basepython = python3
 commands_pre =
-{% if use_flake8 %}
+{% if tox_use_flake8 %}
     mkdir -p {toxinidir}/parts/flake8
 allowlist_externals =
     mkdir
 {% endif %}
 commands =
-{% if use_flake8 %}
+{% if tox_use_flake8 %}
     isort --check-only --diff {toxinidir}/src {toxinidir}/setup.py%(isort_additional_sources)s
     flake8 {toxinidir}/src {toxinidir}/setup.py%(flake8_additional_sources)s
 {% endif %}
 deps =
-{% if use_flake8 %}
+{% if tox_use_flake8 %}
     flake8
     isort
     # Useful flake8 plugins that are Python and Plone specific:
@@ -97,7 +97,7 @@ commands =
     coverage run {envbindir}/test {posargs:-cv}
 {% endif %}
     coverage html
-    coverage report -m --fail-under=%(fail_under)s
+    coverage report -m --fail-under=%(coverage_fail_under)s
 {% for line in coverage_additional %}
 %(line)s
 {% endfor %}


### PR DESCRIPTION
(Adjusting to feedback on PR #259).

Use consistent prefix indicating the section of the config containing the option.

- 'fail_under' -> 'coverage_fail_under'
- 'additional_flake8_config' -> 'flake8_additional_config'
- 'additional_check_manifest_ignores' -> 'check_manifest_additional_ignores'
- 'ignore' -> 'git_ignore'
- 'build_extra' -> 'rtd_build_extra'
- 'run_additional_config' -> 'coverage_run_additional_config'
- 'setup' -> 'manylinux_install_setup'
- 'aarch64_tests' -> 'manylinux_aarch64_tests'
- 'use_flake8' -> 'tox_use_flake8'
- 'services' -> 'gha_services'
- 'additional_config' -> 'gha_additional_config'
- 'additional_exclude' -> 'gha_additional_exclude'
- 'steps_before_checkout' -> 'gha_steps_before_checkout'
- 'additional_install' -> 'gha_additional_install'
- 'additional_build_dependencies' -> 'gha_additional_build_dependencies'
- 'test_environment' -> 'gha_test_environment'
- 'test_commands' -> 'gha_test_commands'
- 'additional_manifest_rules' -> manifest_additional_rules'
- 'additional_rules' -> manifest_additional_rules'