### PR TITLE
Wheel deletion required sudo, the files are owned by root.

### DIFF
--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -416,7 +416,7 @@ jobs:
         run: sudo chown -R $(whoami) ${{ steps.pip-cache-default.outputs.dir }}
 {% if with_future_python %}
       - name: Prevent publishing wheels for unreleased Python versions
-        run: VER=$(echo '%(future_python_version)s' | tr -d .) && rm -f wheelhouse/*-cp${VER}*.whl
+        run: VER=$(echo '%(future_python_version)s' | tr -d .) && && ls -al wheelhouse && sudo rm -f wheelhouse/*-cp${VER}*.whl && ls -al wheelhouse
 {% endif %}
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The first attempt at code to delete wheels for unreleased Python versions made the `manylinux` step fail because the files in the wheelhouse folder are owned by root. Using sudo fixes that. I added a `ls` before and after for diagnostic purposes. Now I can see this works.