### PR TITLE
tests: fix 'tox -e coverage' for 'c-code' projects

### DIFF
--- a/config/c-code/tox.ini.j2
+++ b/config/c-code/tox.ini.j2
@@ -29,6 +29,7 @@ envlist =
 {% include 'tox-testenv.j2' %}
 
 [testenv:coverage]
+usedevelop = true
 basepython = %(coverage_basepython)s
 allowlist_externals =
     mkdir


### PR DESCRIPTION
Closes #271.