### PR TITLE
Prevent force-upgrade during test requirement install

### DIFF
--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -261,7 +261,7 @@ jobs:
           unzip -n dist/%(package_name)s-*whl -d src
           # Use "--pre" here because dependencies with support for this future
           # Python release may only be available as pre-releases
-          pip install --pre -U -e .[test]
+          pip install --pre -e .[test]
 {% endif %}
       - name: Install %(package_name)s
 {% if with_future_python %}
@@ -275,7 +275,7 @@ jobs:
           # when we ask it to load tests from that directory. This
           # might also save some build time?
           unzip -n dist/%(package_name)s-*whl -d src
-          pip install -U -e .[test]
+          pip install -e .[test]
       - name: Run tests with C extensions
         if: ${{ !startsWith(matrix.python-version, 'pypy') }}
         run: |


### PR DESCRIPTION
The `-U` switch will trample over all pins set on the preceding `pip` invocations, in particular the `setuptools` pinned install.

Background: https://github.com/zopefoundation/persistent/actions/runs/10592041991; the just-released `setuptools` 74 seems to cause breakage in `cffi` 1.17 on Windows.