### PR TITLE
Add a tox environment that uses setuptools development code

### DIFF
--- a/config/default/tox-testenv.j2
+++ b/config/default/tox-testenv.j2
@@ -54,3 +54,11 @@ extras =
 {% for line in testenv_additional %}
 %(line)s
 {% endfor %}
+
+[testenv:setuptools-latest]
+basepython = python3
+deps =
+    git+https://github.com/pypa/setuptools.git\#egg=setuptools
+{% for line in testenv_deps %}
+    %(line)s
+{% endfor %}

--- a/config/toolkit/tox.ini.j2
+++ b/config/toolkit/tox.ini.j2
@@ -37,6 +37,16 @@ commands =
 {% for line in testenv_additional %}
 %(line)s
 {% endfor %}
+
+[testenv:setuptools-latest]
+basepython = python3
+deps =
+    git+https://github.com/pypa/setuptools.git\#egg=setuptools
+    zc.buildout >= 3.1
+    wheel > 0.37
+{% for line in testenv_deps %}
+    %(line)s
+{% endfor %}
 {% include 'tox-lint.j2' %}
 {% if with_docs %}
 

--- a/config/zope-product/tox.ini.j2
+++ b/config/zope-product/tox.ini.j2
@@ -38,6 +38,16 @@ commands =
 %(line)s
 {% endfor %}
 
+[testenv:setuptools-latest]
+basepython = python3
+deps =
+    git+https://github.com/pypa/setuptools.git\#egg=setuptools
+    zc.buildout >= 3.1
+    wheel > 0.37
+{% for line in testenv_deps %}
+    %(line)s
+{% endfor %}
+
 {% include 'tox-lint.j2' %}
 {% include 'tox-docs.j2' %}
 


### PR DESCRIPTION
This PR adds a new tox environment `setuptools-latest` that is not run by default and that inherits everything from the base testenv but overrides the dependencies to pull setuptools straight from the main branch on GitHub.

I tested it against Zope itself and `persistent` and nothing fails (yet), so other than eyeballing what ends up in the tox environment's site-packages I can't prove that it really helps. Yet.