### PR TITLE
Add ``pyproject.toml`` to the list of managed files

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -113,12 +113,13 @@ The script does the following steps:
    if it is not yet added.
 2. Copy ``setup.cfg``, ``tox.ini``, ``tests.yml``, ``MANIFEST.in``,
    ``.readthedocs.yaml`` (if needed), and ``.gitignore`` to the repository.
-3. Remove a possibly existing ``.coveragerc`` and ``bootstrap.py``. (Coverage
+3. Create or update a ``pyproject.toml`` project configuration file.
+4. Remove a possibly existing ``.coveragerc`` and ``bootstrap.py``. (Coverage
    is now configured in ``tox.ini`` for packages which are no buildout
    recipes.)
-4. Run the tests via: ``tox``. The ``tox`` script may be either on the current
+5. Run the tests via: ``tox``. The ``tox`` script may be either on the current
    ``$PATH`` or in the ``bin`` subfolder of the current working directory.
-5. Create a branch and a pull request. (Prevent an automatic commit of all
+6. Create a branch and a pull request. (Prevent an automatic commit of all
    changes with the command line switch ``--no-commit``, or an automatic push
    to GitHub using the command line switch ``--no-push``.)
 

--- a/config/README.rst
+++ b/config/README.rst
@@ -111,15 +111,15 @@ The script does the following steps:
 
 1. Add the package name to ``packages.txt`` of the selected configuration type
    if it is not yet added.
-2. Copy ``setup.cfg``, ``tox.ini``, ``tests.yml``, ``MANIFEST.in``,
+1. Copy ``setup.cfg``, ``tox.ini``, ``tests.yml``, ``MANIFEST.in``,
    ``.readthedocs.yaml`` (if needed), and ``.gitignore`` to the repository.
-3. Create or update a ``pyproject.toml`` project configuration file.
-4. Remove a possibly existing ``.coveragerc`` and ``bootstrap.py``. (Coverage
+1. Create or update a ``pyproject.toml`` project configuration file.
+1. Remove a possibly existing ``.coveragerc`` and ``bootstrap.py``. (Coverage
    is now configured in ``tox.ini`` for packages which are no buildout
    recipes.)
-5. Run the tests via: ``tox``. The ``tox`` script may be either on the current
+1. Run the tests via: ``tox``. The ``tox`` script may be either on the current
    ``$PATH`` or in the ``bin`` subfolder of the current working directory.
-6. Create a branch and a pull request. (Prevent an automatic commit of all
+1. Create a branch and a pull request. (Prevent an automatic commit of all
    changes with the command line switch ``--no-commit``, or an automatic push
    to GitHub using the command line switch ``--no-push``.)
 
@@ -127,9 +127,9 @@ After running the script you should manually do the following steps:
 
 1. Check for changes in the updated repository and for the need of a change log
    entry over there.
-2. Make sure the package is activated on https://coveralls.io by trying to add
+1. Make sure the package is activated on https://coveralls.io by trying to add
    the repository name and making it active.
-3. Check in possible changes in the zopefoundation/meta repository.
+1. Check in possible changes in the zopefoundation/meta repository.
 
 
 CLI arguments
@@ -696,10 +696,10 @@ The script does the following steps:
 
 1. It does the following steps for each line in the given ``packages.txt``
    which does not start with ``#``.
-2. Check if there is a repository in ``<path-to-clones>`` with the name of the
+1. Check if there is a repository in ``<path-to-clones>`` with the name of the
    repository. If it does not exist: clone it. If it exists: clean the clone
    from changes, switch to ``master`` branch and pull from origin.
-3. Call the given script with the package name and arguments for the script.
+1. Call the given script with the package name and arguments for the script.
 
 .. caution::
 

--- a/config/README.rst
+++ b/config/README.rst
@@ -109,27 +109,27 @@ See ``--help`` for details.
 
 The script does the following steps:
 
-1. Add the package name to ``packages.txt`` of the selected configuration type
+#. Add the package name to ``packages.txt`` of the selected configuration type
    if it is not yet added.
-2. Copy ``setup.cfg``, ``tox.ini``, ``tests.yml``, ``MANIFEST.in``,
+#. Copy ``setup.cfg``, ``tox.ini``, ``tests.yml``, ``MANIFEST.in``,
    ``.readthedocs.yaml`` (if needed), and ``.gitignore`` to the repository.
-3. Create or update a ``pyproject.toml`` project configuration file.
-4. Remove a possibly existing ``.coveragerc`` and ``bootstrap.py``. (Coverage
+#. Create or update a ``pyproject.toml`` project configuration file.
+#. Remove a possibly existing ``.coveragerc`` and ``bootstrap.py``. (Coverage
    is now configured in ``tox.ini`` for packages which are no buildout
    recipes.)
-5. Run the tests via: ``tox``. The ``tox`` script may be either on the current
+#. Run the tests via: ``tox``. The ``tox`` script may be either on the current
    ``$PATH`` or in the ``bin`` subfolder of the current working directory.
-6. Create a branch and a pull request. (Prevent an automatic commit of all
+#. Create a branch and a pull request. (Prevent an automatic commit of all
    changes with the command line switch ``--no-commit``, or an automatic push
    to GitHub using the command line switch ``--no-push``.)
 
 After running the script you should manually do the following steps:
 
-1. Check for changes in the updated repository and for the need of a change log
+#. Check for changes in the updated repository and for the need of a change log
    entry over there.
-2. Make sure the package is activated on https://coveralls.io by trying to add
+#. Make sure the package is activated on https://coveralls.io by trying to add
    the repository name and making it active.
-3. Check in possible changes in the zopefoundation/meta repository.
+#. Check in possible changes in the zopefoundation/meta repository.
 
 
 CLI arguments
@@ -694,12 +694,12 @@ See ``--help`` for details.
 
 The script does the following steps:
 
-1. It does the following steps for each line in the given ``packages.txt``
+#. It does the following steps for each line in the given ``packages.txt``
    which does not start with ``#``.
-2. Check if there is a repository in ``<path-to-clones>`` with the name of the
+#. Check if there is a repository in ``<path-to-clones>`` with the name of the
    repository. If it does not exist: clone it. If it exists: clean the clone
    from changes, switch to ``master`` branch and pull from origin.
-3. Call the given script with the package name and arguments for the script.
+#. Call the given script with the package name and arguments for the script.
 
 .. caution::
 

--- a/config/README.rst
+++ b/config/README.rst
@@ -111,15 +111,15 @@ The script does the following steps:
 
 1. Add the package name to ``packages.txt`` of the selected configuration type
    if it is not yet added.
-1. Copy ``setup.cfg``, ``tox.ini``, ``tests.yml``, ``MANIFEST.in``,
+2. Copy ``setup.cfg``, ``tox.ini``, ``tests.yml``, ``MANIFEST.in``,
    ``.readthedocs.yaml`` (if needed), and ``.gitignore`` to the repository.
-1. Create or update a ``pyproject.toml`` project configuration file.
-1. Remove a possibly existing ``.coveragerc`` and ``bootstrap.py``. (Coverage
+3. Create or update a ``pyproject.toml`` project configuration file.
+4. Remove a possibly existing ``.coveragerc`` and ``bootstrap.py``. (Coverage
    is now configured in ``tox.ini`` for packages which are no buildout
    recipes.)
-1. Run the tests via: ``tox``. The ``tox`` script may be either on the current
+5. Run the tests via: ``tox``. The ``tox`` script may be either on the current
    ``$PATH`` or in the ``bin`` subfolder of the current working directory.
-1. Create a branch and a pull request. (Prevent an automatic commit of all
+6. Create a branch and a pull request. (Prevent an automatic commit of all
    changes with the command line switch ``--no-commit``, or an automatic push
    to GitHub using the command line switch ``--no-push``.)
 
@@ -127,9 +127,9 @@ After running the script you should manually do the following steps:
 
 1. Check for changes in the updated repository and for the need of a change log
    entry over there.
-1. Make sure the package is activated on https://coveralls.io by trying to add
+2. Make sure the package is activated on https://coveralls.io by trying to add
    the repository name and making it active.
-1. Check in possible changes in the zopefoundation/meta repository.
+3. Check in possible changes in the zopefoundation/meta repository.
 
 
 CLI arguments
@@ -696,10 +696,10 @@ The script does the following steps:
 
 1. It does the following steps for each line in the given ``packages.txt``
    which does not start with ``#``.
-1. Check if there is a repository in ``<path-to-clones>`` with the name of the
+2. Check if there is a repository in ``<path-to-clones>`` with the name of the
    repository. If it does not exist: clone it. If it exists: clean the clone
    from changes, switch to ``master`` branch and pull from origin.
-1. Call the given script with the package name and arguments for the script.
+3. Call the given script with the package name and arguments for the script.
 
 .. caution::
 

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -680,6 +680,7 @@ class PackageConfiguration:
                 ".github/workflows/pre-commit.yml",
                 ".gitignore",
                 ".meta.toml",
+                "pyproject.toml",
                 "setup.cfg",
                 "tox.ini",
             ]

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -629,6 +629,7 @@ class PackageConfiguration:
             early_add = [
                 '.pre-commit-config.yaml',
                 'CONTRIBUTING.md',
+                'pyproject.toml',
             ]
             if self.args.commit:
                 call('git', 'add', *early_add)
@@ -680,7 +681,6 @@ class PackageConfiguration:
                 ".github/workflows/pre-commit.yml",
                 ".gitignore",
                 ".meta.toml",
-                "pyproject.toml",
                 "setup.cfg",
                 "tox.ini",
             ]

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -566,9 +566,10 @@ class PackageConfiguration:
         requires = buildsystem_cfg.get('requires', [])
         setuptools_requirement = [
             x for x in requires if x.startswith('setuptools')]
-        if not setuptools_requirement:
-            requires.append(f'setuptools{SETUPTOOLS_VERSION_SPEC}')
-            buildsystem_cfg['requires'] = requires
+        for setuptools_req in setuptools_requirement:
+            requires.remove(setuptools_req)
+        requires.append(f'setuptools{SETUPTOOLS_VERSION_SPEC}')
+        buildsystem_cfg['requires'] = sorted(requires)
 
         # Insert sane default for build-system:build-backend
         build_backend = buildsystem_cfg.get('build-backend', '')

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -580,7 +580,7 @@ class PackageConfiguration:
         with open(pyproject_toml_path, 'w') as fp:
             fp.write(META_HINT.format(config_type=self.config_type))
             fp.write('\n')
-            tomlkit.dump(pyproject_toml, fp)
+            tomlkit.dump(pyproject_toml, fp, sort_keys=True)
 
     def copy_with_meta(
             self, template_name, destination, config_type,


### PR DESCRIPTION
This PR is an alternative implementation of #270. It uses `tomlkit` to load an existing file and then merges some sane defaults before writing it to disk.

Successfully tested against Zope, which has no pre-existing `pyproject.toml`, and `BTrees`, which does.

@dwt: Can you check to see if this works for you and gets rid of the warnings?
