### PR TITLE
Move Python 3.13 into the stable Python category and call a notional Python 3.14 "future Python"

### DIFF
--- a/config/c-code/manylinux-install.sh.j2
+++ b/config/c-code/manylinux-install.sh.j2
@@ -30,13 +30,14 @@ yum -y install libffi-devel
 tox_env_map() {
     case $1 in
 {% if with_future_python %}
-        *"cp313"*) echo 'py313';;
+        *"cp314"*) echo 'py314';;
 {% endif %}
         *"cp38"*) echo 'py38';;
         *"cp39"*) echo 'py39';;
         *"cp310"*) echo 'py310';;
         *"cp311"*) echo 'py311';;
         *"cp312"*) echo 'py312';;
+        *"cp313"*) echo 'py313';;
         *) echo 'py';;
     esac
 }
@@ -45,15 +46,16 @@ tox_env_map() {
 for PYBIN in /opt/python/*/bin; do
     if \
 {% if with_future_python %}
-       [[ "${PYBIN}" == *"cp313/"* ]] || \
+       [[ "${PYBIN}" == *"cp314/"* ]] || \
 {% endif %}
        [[ "${PYBIN}" == *"cp311/"* ]] || \
        [[ "${PYBIN}" == *"cp312/"* ]] || \
+       [[ "${PYBIN}" == *"cp313/"* ]] || \
        [[ "${PYBIN}" == *"cp38/"* ]] || \
        [[ "${PYBIN}" == *"cp39/"* ]] || \
        [[ "${PYBIN}" == *"cp310/"* ]] ; then
 {% if with_future_python %}
-        if [[ "${PYBIN}" == *"cp313/"* ]] ; then
+        if [[ "${PYBIN}" == *"cp314/"* ]] ; then
             "${PYBIN}/pip" install --pre -e /io/
             "${PYBIN}/pip" wheel /io/ --pre -w wheelhouse/
         else

--- a/config/c-code/manylinux-install.sh.j2
+++ b/config/c-code/manylinux-install.sh.j2
@@ -29,15 +29,15 @@ yum -y install libffi-devel
 
 tox_env_map() {
     case $1 in
-{% if with_future_python %}
-        *"cp314"*) echo 'py314';;
-{% endif %}
         *"cp38"*) echo 'py38';;
         *"cp39"*) echo 'py39';;
         *"cp310"*) echo 'py310';;
         *"cp311"*) echo 'py311';;
         *"cp312"*) echo 'py312';;
         *"cp313"*) echo 'py313';;
+{% if with_future_python %}
+        *"cp%(future_python_shortversion)s"*) echo 'py%(future_python_shortversion)s';;
+{% endif %}
         *) echo 'py';;
     esac
 }
@@ -46,7 +46,7 @@ tox_env_map() {
 for PYBIN in /opt/python/*/bin; do
     if \
 {% if with_future_python %}
-       [[ "${PYBIN}" == *"cp314/"* ]] || \
+       [[ "${PYBIN}" == *"cp%(future_python_shortversion)s/"* ]] || \
 {% endif %}
        [[ "${PYBIN}" == *"cp311/"* ]] || \
        [[ "${PYBIN}" == *"cp312/"* ]] || \
@@ -55,7 +55,7 @@ for PYBIN in /opt/python/*/bin; do
        [[ "${PYBIN}" == *"cp39/"* ]] || \
        [[ "${PYBIN}" == *"cp310/"* ]] ; then
 {% if with_future_python %}
-        if [[ "${PYBIN}" == *"cp314/"* ]] ; then
+        if [[ "${PYBIN}" == *"cp%(future_python_shortversion)s/"* ]] ; then
             "${PYBIN}/pip" install --pre -e /io/
             "${PYBIN}/pip" wheel /io/ --pre -w wheelhouse/
         else

--- a/config/c-code/manylinux-install.sh.j2
+++ b/config/c-code/manylinux-install.sh.j2
@@ -29,12 +29,9 @@ yum -y install libffi-devel
 
 tox_env_map() {
     case $1 in
-        *"cp38"*) echo 'py38';;
-        *"cp39"*) echo 'py39';;
-        *"cp310"*) echo 'py310';;
-        *"cp311"*) echo 'py311';;
-        *"cp312"*) echo 'py312';;
-        *"cp313"*) echo 'py313';;
+{% for py_version in supported_python_versions %}
+        *"cp%(py_version)s"*) echo 'py%(py_version)s';;
+{% endfor %}
 {% if with_future_python %}
         *"cp%(future_python_shortversion)s"*) echo 'py%(future_python_shortversion)s';;
 {% endif %}
@@ -45,15 +42,15 @@ tox_env_map() {
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
     if \
-       [[ "${PYBIN}" == *"cp311/"* ]] || \
-       [[ "${PYBIN}" == *"cp312/"* ]] || \
-       [[ "${PYBIN}" == *"cp313/"* ]] || \
-{% if with_future_python %}
-       [[ "${PYBIN}" == *"cp%(future_python_shortversion)s/"* ]] || \
+{% for py_version in supported_python_versions %}
+       [[ "${PYBIN}" == *"cp%(py_version)s/"* ]] {% if py_version != stop_at %}|| \
 {% endif %}
-       [[ "${PYBIN}" == *"cp38/"* ]] || \
-       [[ "${PYBIN}" == *"cp39/"* ]] || \
-       [[ "${PYBIN}" == *"cp310/"* ]] ; then
+{% endfor %}
+{% if with_future_python %}
+       [[ "${PYBIN}" == *"cp%(future_python_shortversion)s/"* ]] ; then
+{% else %}
+; then
+{% endif %}
 {% if with_future_python %}
         if [[ "${PYBIN}" == *"cp%(future_python_shortversion)s/"* ]] ; then
             "${PYBIN}/pip" install --pre -e /io/

--- a/config/c-code/manylinux-install.sh.j2
+++ b/config/c-code/manylinux-install.sh.j2
@@ -45,12 +45,12 @@ tox_env_map() {
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
     if \
-{% if with_future_python %}
-       [[ "${PYBIN}" == *"cp%(future_python_shortversion)s/"* ]] || \
-{% endif %}
        [[ "${PYBIN}" == *"cp311/"* ]] || \
        [[ "${PYBIN}" == *"cp312/"* ]] || \
        [[ "${PYBIN}" == *"cp313/"* ]] || \
+{% if with_future_python %}
+       [[ "${PYBIN}" == *"cp%(future_python_shortversion)s/"* ]] || \
+{% endif %}
        [[ "${PYBIN}" == *"cp38/"* ]] || \
        [[ "${PYBIN}" == *"cp39/"* ]] || \
        [[ "${PYBIN}" == *"cp310/"* ]] ; then

--- a/config/c-code/tests-cache.j2
+++ b/config/c-code/tests-cache.j2
@@ -4,9 +4,7 @@
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-{% if with_future_python %}
           allow-prereleases: true
-{% endif %}
       ###
       # Caching.
       # This actually *restores* a cache and schedules a cleanup action

--- a/config/c-code/tests-strategy.j2
+++ b/config/c-code/tests-strategy.j2
@@ -5,12 +5,9 @@
 {% if with_pypy %}
           - "pypy-%(pypy_version)s"
 {% endif %}
-          - "3.8"
-          - "3.9"
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
+{% for (py_long_version, py_short_version) in supported_python_versions %}
+          - "%(py_long_version)s"
+{% endfor %}
 {% if with_future_python %}
           - "%(future_python_version)s"
 {% endif %}

--- a/config/c-code/tests-strategy.j2
+++ b/config/c-code/tests-strategy.j2
@@ -10,6 +10,7 @@
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
 {% if with_future_python %}
           - "%(future_python_version)s"
 {% endif %}

--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -269,7 +269,7 @@ jobs:
 {% endif %}
         run: |
           pip install -U wheel "setuptools %(setuptools_version_spec)s"
-          pip install -U coverage
+          pip install -U coverage[toml]
           pip install -U 'cffi; platform_python_implementation == "CPython"'
           # Unzip into src/ so that testrunner can find the .so files
           # when we ask it to load tests from that directory. This
@@ -334,7 +334,7 @@ jobs:
       - name: Install %(package_name)s
         run: |
           pip install -U wheel
-          pip install -U coverage
+          pip install -U coverage[toml]
           pip install -U  "`ls dist/%(package_name)s-*.whl`[docs]"
       - name: Build docs
         env:

--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -254,7 +254,7 @@ jobs:
           pip install -U wheel "setuptools %(setuptools_version_spec)s"
           # coverage might have a wheel on PyPI for a future python version which is
           # not ABI compatible with the current one, so build it from sdist:
-          pip install -U --no-binary :all: coverage
+          pip install -U --no-binary :all: coverage[toml]
           # Unzip into src/ so that testrunner can find the .so files
           # when we ask it to load tests from that directory. This
           # might also save some build time?
@@ -269,7 +269,7 @@ jobs:
 {% endif %}
         run: |
           pip install -U wheel "setuptools %(setuptools_version_spec)s"
-          pip install -U coverage
+          pip install -U coverage[toml]
           pip install -U 'cffi; platform_python_implementation == "CPython"'
           # Unzip into src/ so that testrunner can find the .so files
           # when we ask it to load tests from that directory. This
@@ -334,7 +334,7 @@ jobs:
       - name: Install %(package_name)s
         run: |
           pip install -U wheel
-          pip install -U coverage
+          pip install -U coverage[toml]
           pip install -U  "`ls dist/%(package_name)s-*.whl`[docs]"
       - name: Build docs
         env:

--- a/config/c-code/tests.yml.j2
+++ b/config/c-code/tests.yml.j2
@@ -254,7 +254,7 @@ jobs:
           pip install -U wheel "setuptools %(setuptools_version_spec)s"
           # coverage might have a wheel on PyPI for a future python version which is
           # not ABI compatible with the current one, so build it from sdist:
-          pip install -U --no-binary :all: coverage[toml]
+          pip install -U --no-binary :all: coverage
           # Unzip into src/ so that testrunner can find the .so files
           # when we ask it to load tests from that directory. This
           # might also save some build time?
@@ -269,7 +269,7 @@ jobs:
 {% endif %}
         run: |
           pip install -U wheel "setuptools %(setuptools_version_spec)s"
-          pip install -U coverage[toml]
+          pip install -U coverage
           pip install -U 'cffi; platform_python_implementation == "CPython"'
           # Unzip into src/ so that testrunner can find the .so files
           # when we ask it to load tests from that directory. This
@@ -334,7 +334,7 @@ jobs:
       - name: Install %(package_name)s
         run: |
           pip install -U wheel
-          pip install -U coverage[toml]
+          pip install -U coverage
           pip install -U  "`ls dist/%(package_name)s-*.whl`[docs]"
       - name: Build docs
         env:

--- a/config/c-code/tox.ini.j2
+++ b/config/c-code/tox.ini.j2
@@ -11,8 +11,9 @@ envlist =
     py310,py310-pure
     py311,py311-pure
     py312,py312-pure
-{% if with_future_python %}
     py313,py313-pure
+{% if with_future_python %}
+    py314,py314-pure
 {% endif %}
 {% if with_pypy %}
     pypy3

--- a/config/c-code/tox.ini.j2
+++ b/config/c-code/tox.ini.j2
@@ -6,12 +6,9 @@
 minversion = 4.0
 envlist =
     lint
-    py38,py38-pure
-    py39,py39-pure
-    py310,py310-pure
-    py311,py311-pure
-    py312,py312-pure
-    py313,py313-pure
+{% for py_version in supported_python_versions %}
+    py%(py_version)s,py%(py_version)s-pure
+{% endfor %}
 {% if with_future_python %}
     py%(future_python_shortversion)s,py%(future_python_shortversion)s-pure
 {% endif %}

--- a/config/c-code/tox.ini.j2
+++ b/config/c-code/tox.ini.j2
@@ -13,7 +13,7 @@ envlist =
     py312,py312-pure
     py313,py313-pure
 {% if with_future_python %}
-    py314,py314-pure
+    py%(future_python_shortversion)s,py%(future_python_shortversion)s-pure
 {% endif %}
 {% if with_pypy %}
     pypy3

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -492,8 +492,9 @@ class PackageConfiguration:
         gha_test_commands = self.gh_option('test-commands')
         require_cffi = self.meta_cfg.get(
             'c-code', {}).get('require-cffi', False)
-        py_version_matrix = [x for x in zip(supported_python_versions(False),
-                                            supported_python_versions(True))]
+        py_version_matrix = [
+            x for x in zip(supported_python_versions(short_version=False),
+                           supported_python_versions(short_version=True))]
         self.copy_with_meta(
             'tests.yml.j2',
             workflows / 'tests.yml',

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -474,7 +474,7 @@ class PackageConfiguration:
             docs_deps=docs_deps,
             setuptools_version_spec=SETUPTOOLS_VERSION_SPEC,
             future_python_shortversion=FUTURE_PYTHON_SHORTVERSION,
-            supported_python_versions=supported_python_versions(True),
+            supported_python_versions=supported_python_versions(short_version=True),
         )
 
     def tests_yml(self):

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -37,6 +37,7 @@ import shutil
 import tomlkit
 
 
+FUTURE_PYTHON_SHORTVERSION = FUTURE_PYTHON_VERSION.replace('.', '')
 META_HINT = """\
 # Generated from:
 # https://github.com/zopefoundation/meta/tree/master/config/{config_type}"""
@@ -380,6 +381,7 @@ class PackageConfiguration:
                 manylinux_install_setup=manylinux_install_setup,
                 manylinux_aarch64_tests=manylinux_aarch64_tests,
                 with_future_python=self.with_future_python,
+                future_python_shortversion=FUTURE_PYTHON_SHORTVERSION,
             )
             (self.path / '.manylinux-install.sh').chmod(0o755)
             self.add_manylinux = True
@@ -462,6 +464,7 @@ class PackageConfiguration:
             with_sphinx_doctests=self.with_sphinx_doctests,
             docs_deps=docs_deps,
             setuptools_version_spec=SETUPTOOLS_VERSION_SPEC,
+            future_python_shortversion=FUTURE_PYTHON_SHORTVERSION,
         )
 
     def tests_yml(self):
@@ -506,6 +509,7 @@ class PackageConfiguration:
             manylinux_x86_64=MANYLINUX_X86_64,
             pypy_version=PYPY_VERSION,
             setuptools_version_spec=SETUPTOOLS_VERSION_SPEC,
+            future_python_shortversion=FUTURE_PYTHON_SHORTVERSION,
         )
 
     def pre_commit_yml(self):

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -474,7 +474,8 @@ class PackageConfiguration:
             docs_deps=docs_deps,
             setuptools_version_spec=SETUPTOOLS_VERSION_SPEC,
             future_python_shortversion=FUTURE_PYTHON_SHORTVERSION,
-            supported_python_versions=supported_python_versions(short_version=True),
+            supported_python_versions=supported_python_versions(
+                short_version=True),
         )
 
     def tests_yml(self):

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -388,7 +388,8 @@ class PackageConfiguration:
                 manylinux_aarch64_tests=manylinux_aarch64_tests,
                 with_future_python=self.with_future_python,
                 future_python_shortversion=FUTURE_PYTHON_SHORTVERSION,
-                supported_python_versions=supported_python_versions(True),
+                supported_python_versions=supported_python_versions(
+                    short_version=True),
                 stop_at=stop_at,
             )
             (self.path / '.manylinux-install.sh').chmod(0o755)

--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -35,24 +35,21 @@ jobs:
 {% endif %}
         config:
         # [Python version, tox env]
-        - ["3.11",  "release-check"]
-        - ["3.8",   "py38"]
-        - ["3.9",   "py39"]
-        - ["3.10",  "py310"]
-        - ["3.11",  "py311"]
-        - ["3.12",  "py312"]
-        - ["3.13",  "py313"]
+        - ["3.11", "release-check"]
+{% for (py_long_version, py_short_version) in supported_python_versions %}
+        - ["%(py_long_version)s", "py%(py_short_version)s"]
+{% endfor %}
 {% if with_future_python %}
-        - ["%(future_python_version)s",  "py%(future_python_shortversion)s"]
+        - ["%(future_python_version)s", "py%(future_python_shortversion)s"]
 {% endif %}
 {% if with_pypy %}
-        - ["pypy-3.10", "pypy3"]
+        - ["pypy-%(pypi_version)s", "pypy3"]
 {% endif %}
 {% if with_docs %}
-        - ["3.11",   "docs"]
+        - ["3.11", "docs"]
 {% endif %}
 {% if with_coverage %}
-        - ["3.11",   "coverage"]
+        - ["3.11", "coverage"]
 {% endif %}
 {% for line in gha_additional_config %}
         %(line)s
@@ -61,18 +58,18 @@ jobs:
         exclude:
 {% endif %}
 {% if with_windows %}
-          - { os: ["windows", "windows-latest"], config: ["3.11",  "release-check"] }
+          - { os: ["windows", "windows-latest"], config: ["3.11", "release-check"] }
   {% if with_docs %}
-          - { os: ["windows", "windows-latest"], config: ["3.11",  "docs"] }
+          - { os: ["windows", "windows-latest"], config: ["3.11", "docs"] }
   {% endif %}
-          - { os: ["windows", "windows-latest"], config: ["3.11",  "coverage"] }
+          - { os: ["windows", "windows-latest"], config: ["3.11", "coverage"] }
 {% endif %}
 {% if with_macos %}
-          - { os: ["macos", "macos-latest"], config: ["3.11",  "release-check"] }
+          - { os: ["macos", "macos-latest"], config: ["3.11", "release-check"] }
   {% if with_docs %}
-          - { os: ["macos", "macos-latest"], config: ["3.11",  "docs"] }
+          - { os: ["macos", "macos-latest"], config: ["3.11", "docs"] }
   {% endif %}
-          - { os: ["macos", "macos-latest"], config: ["3.11",  "coverage"] }
+          - { os: ["macos", "macos-latest"], config: ["3.11", "coverage"] }
 {% endif %}
 {% for line in gha_additional_exclude %}
           %(line)s

--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -41,8 +41,9 @@ jobs:
         - ["3.10",  "py310"]
         - ["3.11",  "py311"]
         - ["3.12",  "py312"]
+        - ["3.13",  "py313"]
 {% if with_future_python %}
-        - ["%(future_python_version)s",  "py313"]
+        - ["%(future_python_version)s",  "py314"]
 {% endif %}
 {% if with_pypy %}
         - ["pypy-3.10", "pypy3"]
@@ -93,9 +94,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.config[0] }}
-{% if with_future_python %}
         allow-prereleases: true
-{% endif %}
     - name: Pip cache
       uses: actions/cache@v4
       with:

--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -43,7 +43,7 @@ jobs:
         - ["3.12",  "py312"]
         - ["3.13",  "py313"]
 {% if with_future_python %}
-        - ["%(future_python_version)s",  "py314"]
+        - ["%(future_python_version)s",  "py%(future_python_shortversion)s"]
 {% endif %}
 {% if with_pypy %}
         - ["pypy-3.10", "pypy3"]

--- a/config/default/tox-envlist.j2
+++ b/config/default/tox-envlist.j2
@@ -8,8 +8,9 @@ envlist =
     py310
     py311
     py312
-{% if with_future_python %}
     py313
+{% if with_future_python %}
+    py314
 {% endif %}
 {% if with_pypy %}
     pypy3

--- a/config/default/tox-envlist.j2
+++ b/config/default/tox-envlist.j2
@@ -10,7 +10,7 @@ envlist =
     py312
     py313
 {% if with_future_python %}
-    py314
+    py%(future_python_shortversion)s
 {% endif %}
 {% if with_pypy %}
     pypy3

--- a/config/default/tox-envlist.j2
+++ b/config/default/tox-envlist.j2
@@ -3,12 +3,9 @@ minversion = 3.18
 envlist =
     release-check
     lint
-    py38
-    py39
-    py310
-    py311
-    py312
-    py313
+{% for py_version in supported_python_versions %}
+    py%(py_version)s
+{% endfor %}
 {% if with_future_python %}
     py%(future_python_shortversion)s
 {% endif %}

--- a/config/default/tox-testenv.j2
+++ b/config/default/tox-testenv.j2
@@ -8,7 +8,7 @@ package = wheel
 wheel_build_env = .pkg
 {% endif %}
 {% if with_future_python %}
-pip_pre = py314: true
+pip_pre = py%(future_python_shortversion)s: true
 {% endif %}
 deps =
     setuptools  %(setuptools_version_spec)s

--- a/config/default/tox-testenv.j2
+++ b/config/default/tox-testenv.j2
@@ -8,7 +8,7 @@ package = wheel
 wheel_build_env = .pkg
 {% endif %}
 {% if with_future_python %}
-pip_pre = py313: true
+pip_pre = py314: true
 {% endif %}
 deps =
     setuptools  %(setuptools_version_spec)s

--- a/config/default/tox-testenv.j2
+++ b/config/default/tox-testenv.j2
@@ -24,8 +24,6 @@ setenv =
     %(line)s
   {% endfor %}
 {% endif %}
-    py312: VIRTUALENV_PIP=23.1.2
-    py312: PIP_REQUIRE_VIRTUALENV=0
 {% if testenv_commands_pre %}
 commands_pre =
   {% for line in testenv_commands_pre %}

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -1,8 +1,8 @@
 check-python-versions==0.22.0
 Jinja2==3.1.4
+packaging==24.1
 pyupgrade==3.16.0
+requests==2.32.3
 tomlkit==0.13.2
 tox==4.18.1
-requests==2.32.3
 zest.releaser==9.2.0
-packaging==24.1

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -1,7 +1,8 @@
-check-python-versions==0.21.3
+check-python-versions==0.22.0
 Jinja2==3.1.4
-pyupgrade==3.3.2
-tomlkit==0.12.1
-tox==4.8.0
-requests==2.32.0
-zest.releaser==8.0.0
+pyupgrade==3.16.0
+tomlkit==0.13.2
+tox==4.18.1
+requests==2.32.3
+zest.releaser==9.2.0
+packaging==24.1

--- a/config/shared/packages.py
+++ b/config/shared/packages.py
@@ -13,6 +13,7 @@
 import configparser
 import itertools
 import pathlib
+from packaging.version import parse as parse_version
 
 
 TYPES = ['buildout-recipe', 'c-code', 'pure-python', 'zope-product', 'toolkit']
@@ -20,10 +21,6 @@ ORG = 'zopefoundation'
 BASE_PATH = pathlib.Path(__file__).parent.parent
 OLDEST_PYTHON_VERSION = '3.8'
 NEWEST_PYTHON_VERSION = '3.13'
-SUPPORTED_PYTHON_VERSIONS = [
-    f'3.{i}' for i in range(int(OLDEST_PYTHON_VERSION.replace('3.', '')),
-                            int(NEWEST_PYTHON_VERSION.replace('3.', '')) + 1)
-]
 FUTURE_PYTHON_VERSION = '3.14'
 PYPY_VERSION = '3.10'
 SETUPTOOLS_VERSION_SPEC = '<74'
@@ -145,6 +142,31 @@ def parse_additional_config(cfg):
             data[key] = value
 
     return data
+
+
+def supported_python_versions(short_version=False):
+    """Create a list containing all supported Python versions
+
+    Uses the configured oldest and newest Python versions to compute a list
+    containing all versions from oldest to newest that can be iterated over in
+    the templates.
+
+    Kwargs:
+
+        short_version (bool):
+            Return short versions like "313" instead of "3.13"
+    """
+    minor_versions = []
+    oldest_python = parse_version(OLDEST_PYTHON_VERSION)
+    newest_python = parse_version(NEWEST_PYTHON_VERSION)
+    for minor in range(oldest_python.minor, newest_python.minor+1):
+        minor_versions.append(minor)
+    supported = [f'{oldest_python.major}.{minor}' for minor in minor_versions]
+
+    if short_version:
+        return [x.replace('.', '') for x in supported]
+
+    return supported
 
 
 def list_packages(path: pathlib.Path) -> list:

--- a/config/shared/packages.py
+++ b/config/shared/packages.py
@@ -19,12 +19,12 @@ TYPES = ['buildout-recipe', 'c-code', 'pure-python', 'zope-product', 'toolkit']
 ORG = 'zopefoundation'
 BASE_PATH = pathlib.Path(__file__).parent.parent
 OLDEST_PYTHON_VERSION = '3.8'
-NEWEST_PYTHON_VERSION = '3.12'
+NEWEST_PYTHON_VERSION = '3.13'
 SUPPORTED_PYTHON_VERSIONS = [
     f'3.{i}' for i in range(int(OLDEST_PYTHON_VERSION.replace('3.', '')),
                             int(NEWEST_PYTHON_VERSION.replace('3.', '')) + 1)
 ]
-FUTURE_PYTHON_VERSION = '3.13'
+FUTURE_PYTHON_VERSION = '3.14'
 PYPY_VERSION = '3.10'
 SETUPTOOLS_VERSION_SPEC = '<74'
 MANYLINUX_PYTHON_VERSION = '3.11'

--- a/config/shared/packages.py
+++ b/config/shared/packages.py
@@ -10,10 +10,10 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
+from packaging.version import parse as parse_version
 import configparser
 import itertools
 import pathlib
-from packaging.version import parse as parse_version
 
 
 TYPES = ['buildout-recipe', 'c-code', 'pure-python', 'zope-product', 'toolkit']

--- a/config/toolkit/tox.ini.j2
+++ b/config/toolkit/tox.ini.j2
@@ -16,8 +16,6 @@ setenv =
     %(line)s
   {% endfor %}
 {% endif %}
-    py312: VIRTUALENV_PIP=23.1.2
-    py312: PIP_REQUIRE_VIRTUALENV=0
 commands_pre =
 {% if testenv_commands_pre %}
   {% for line in testenv_commands_pre %}

--- a/config/update-python-support.py
+++ b/config/update-python-support.py
@@ -16,7 +16,7 @@ from shared.call import wait_for_accept
 from shared.git import get_branch_name
 from shared.git import git_branch
 from shared.packages import OLDEST_PYTHON_VERSION
-from shared.packages import SUPPORTED_PYTHON_VERSIONS
+from shared.packages import supported_python_versions
 from shared.path import change_dir
 import argparse
 import collections
@@ -85,8 +85,8 @@ with change_dir(path) as cwd_str:
 
     current_python_versions = get_tox_ini_python_versions('tox.ini')
     no_longer_supported = (set(current_python_versions) -
-                           set(SUPPORTED_PYTHON_VERSIONS))
-    not_yet_supported = (set(SUPPORTED_PYTHON_VERSIONS) -
+                           set(supported_python_versions()))
+    not_yet_supported = (set(supported_python_versions()) -
                          set(current_python_versions))
 
     non_interactive_params = []
@@ -97,7 +97,7 @@ with change_dir(path) as cwd_str:
 
     if no_longer_supported or not_yet_supported:
         call(bin_dir / 'bumpversion', '--feature', *non_interactive_params)
-    python_versions_args = ['--add=' + ','.join(SUPPORTED_PYTHON_VERSIONS)]
+    python_versions_args = ['--add=' + ','.join(supported_python_versions())]
     if no_longer_supported:
         for version in sorted(list(no_longer_supported)):
             call(bin_dir / 'addchangelogentry',

--- a/config/zope-product/tox.ini.j2
+++ b/config/zope-product/tox.ini.j2
@@ -16,8 +16,6 @@ setenv =
     %(line)s
   {% endfor %}
 {% endif %}
-    py312: VIRTUALENV_PIP=23.1.2
-    py312: PIP_REQUIRE_VIRTUALENV=0
 commands_pre =
 {% if testenv_commands_pre %}
   {% for line in testenv_commands_pre %}


### PR DESCRIPTION
This PR moves Python 3.13 into the list of normally tested and compatible Python versions and ends its status as future Python. Since 3.13.0.rc1 it is ABI-stable and there won't be any surprises, so we can start declaring full support where possible. I want to start doing the binary packages.

