### PR TITLE
Add a pyproject.toml to config/

### DIFF
--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,0 +1,2 @@
+uv.lock
+*.egg-info

--- a/config/pyproject.toml
+++ b/config/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "zopefoundation-meta-config"
+version = "0.1.0"
+description = "Bring the configuration of the zopefoundation packages into a common state and keep it there."
+readme = "README.rst"
+requires-python = ">=3.8.1"
+dynamic = ["dependencies"]
+
+[tool.setuptools]
+py-modules = []
+
+[tool.setuptools.dynamic]
+dependencies = {file = "requirements.txt"}


### PR DESCRIPTION
My current motivation for this is to be able to run

    uv run config-package.py

and have it set up a ./.venv/ with all the dependencies automatically (and keep it up to date when requirements.txt change).

It appears to work fine.