### PR TITLE
Avoid generating an empty setenv =

### DIFF
--- a/config/default/tox-testenv.j2
+++ b/config/default/tox-testenv.j2
@@ -18,8 +18,8 @@ deps =
   {% if with_sphinx_doctests and with_future_python %}
     Sphinx
   {% endif %}
-setenv =
 {% if testenv_setenv %}
+setenv =
   {% for line in testenv_setenv %}
     %(line)s
   {% endfor %}


### PR DESCRIPTION
Because it breaks packages that have a

    test-additional = ["setenv =", ...]

in their .meta.toml, like zope.publisher.