### PR TITLE
Support for specifying a minimum supported Python version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Change log
 1.1 (unreleased)
 ----------------
 
+- Allow specifying a minimum supported Python version other than the previously
+  hardcoded default of Python 3.8.
+
 
 1.0 (2024-10-02)
 ----------------

--- a/docs/narr.rst
+++ b/docs/narr.rst
@@ -176,6 +176,10 @@ The following options are only needed one time as their values are stored in
   a final release thus it is not yet generally supported by the zopefoundation
   packages.
 
+--oldest-python
+  The oldest version of Python supported by this package. Specified as version
+  number, e.g. ``3.8``.
+
 --with-docs
   Enable building the documentation using Sphinx. This will also create a
   configuration file `.readthedocs.yaml` for integration with

--- a/docs/narr.rst
+++ b/docs/narr.rst
@@ -178,7 +178,8 @@ The following options are only needed one time as their values are stored in
 
 --oldest-python
   The oldest version of Python supported by this package. Specified as version
-  number, e.g. ``3.8``.
+  number, e.g. ``3.8``. This setting is optional and defaults to the lowest
+  Python version generally supported by zopefoundation packages.
 
 --with-docs
   Enable building the documentation using Sphinx. This will also create a

--- a/src/zope/meta/config_package.py
+++ b/src/zope/meta/config_package.py
@@ -110,9 +110,8 @@ def handle_command_line_arguments():
     parser.add_argument(
         '--oldest-python',
         dest='oldest_python',
-        default=OLDEST_PYTHON_VERSION,
-        help='Oldest supported Python version. Defaults to'
-             f'Python {OLDEST_PYTHON_VERSION}.')
+        help='Oldest supported Python version. Defaults to:'
+             f' {OLDEST_PYTHON_VERSION}.')
     parser.add_argument(
         '--with-docs',
         # people (me) use --with-sphinx and accidentally
@@ -207,8 +206,9 @@ class PackageConfiguration:
 
     @cached_property
     def oldest_python(self):
-        value = (self.meta_cfg['python'].get('oldest-python') or
-                 self.args.oldest_python)
+        value = (self.args.oldest_python or
+                 self.meta_cfg['python'].get('oldest-python') or
+                 OLDEST_PYTHON_VERSION)
         try:
             version = parse_version(value)
         except InvalidVersion:

--- a/src/zope/meta/config_package.py
+++ b/src/zope/meta/config_package.py
@@ -112,7 +112,7 @@ def handle_command_line_arguments():
         dest='oldest_python',
         default=OLDEST_PYTHON_VERSION,
         help='Oldest supported Python version. Defaults to'
-             f'Python {OLDEST_PYTHON_VERSION}')
+             f'Python {OLDEST_PYTHON_VERSION}.')
     parser.add_argument(
         '--with-docs',
         # people (me) use --with-sphinx and accidentally

--- a/src/zope/meta/config_package.py
+++ b/src/zope/meta/config_package.py
@@ -414,7 +414,7 @@ class PackageConfiguration:
                 with_future_python=self.with_future_python,
                 future_python_shortversion=FUTURE_PYTHON_SHORTVERSION,
                 supported_python_versions=supported_python_versions(
-                    short_version=True),
+                    self.oldest_python, short_version=True),
                 stop_at=stop_at,
             )
             (self.path / '.manylinux-install.sh').chmod(0o755)
@@ -500,7 +500,7 @@ class PackageConfiguration:
             setuptools_version_spec=SETUPTOOLS_VERSION_SPEC,
             future_python_shortversion=FUTURE_PYTHON_SHORTVERSION,
             supported_python_versions=supported_python_versions(
-                short_version=True),
+                self.oldest_python, short_version=True),
         )
 
     def tests_yml(self):
@@ -519,8 +519,10 @@ class PackageConfiguration:
         require_cffi = self.meta_cfg.get(
             'c-code', {}).get('require-cffi', False)
         py_version_matrix = [
-            x for x in zip(supported_python_versions(short_version=False),
-                           supported_python_versions(short_version=True))]
+            x for x in zip(supported_python_versions(self.oldest_python,
+                                                     short_version=False),
+                           supported_python_versions(self.oldest_python,
+                                                     short_version=True))]
         self.copy_with_meta(
             'tests.yml.j2',
             workflows / 'tests.yml',

--- a/src/zope/meta/set_branch_protection_rules.py
+++ b/src/zope/meta/set_branch_protection_rules.py
@@ -23,7 +23,6 @@ from .shared.packages import PYPY_VERSION
 
 
 BASE_URL = f'https://raw.githubusercontent.com/{ORG}'
-OLDEST_PYTHON = f'py{OLDEST_PYTHON_VERSION.replace(".", "")}'
 NEWEST_PYTHON = f'py{NEWEST_PYTHON_VERSION.replace(".", "")}'
 DEFAULT_BRANCH = 'master'
 
@@ -71,6 +70,9 @@ def set_branch_protection(
     template = meta_toml['meta']['template']
     with_docs = meta_toml['python'].get('with-docs', False)
     with_pypy = meta_toml['python']['with-pypy']
+    oldest_python_version = meta_toml['python'].get('oldest-python',
+                                                    OLDEST_PYTHON_VERSION)
+    oldest_python = oldest_python_version.replace('.', '')
     with_windows = meta_toml['python']['with-windows']
     with_macos = meta_toml['python']['with-macos']
     required = ['linting']
@@ -79,9 +81,9 @@ def set_branch_protection(
             f'manylinux ({MANYLINUX_PYTHON_VERSION}, {MANYLINUX_AARCH64})',
             f'manylinux ({MANYLINUX_PYTHON_VERSION}, {MANYLINUX_I686})',
             f'manylinux ({MANYLINUX_PYTHON_VERSION}, {MANYLINUX_X86_64})',
-            f'test ({OLDEST_PYTHON_VERSION}, macos-latest)',
+            f'test ({oldest_python_version}, macos-latest)',
             f'test ({NEWEST_PYTHON_VERSION}, macos-latest)',
-            f'test ({OLDEST_PYTHON_VERSION}, ubuntu-latest)',
+            f'test ({oldest_python_version}, ubuntu-latest)',
             f'test ({NEWEST_PYTHON_VERSION}, ubuntu-latest)',
             'coveralls_finish',
         ])
@@ -93,23 +95,23 @@ def set_branch_protection(
             required.append(f'test (pypy-{PYPY_VERSION}, windows-latest)')
         if with_windows:
             required.extend([
-                f'test ({OLDEST_PYTHON_VERSION}, windows-latest)',
+                f'test ({oldest_python_version}, windows-latest)',
                 f'test ({NEWEST_PYTHON_VERSION}, windows-latest)',
             ])
     elif with_windows or with_macos:
         required.extend([
             'ubuntu-coverage',
-            f'ubuntu-{OLDEST_PYTHON}',
+            f'ubuntu-{oldest_python}',
             f'ubuntu-{NEWEST_PYTHON}',
         ])
         if with_windows:
             required.extend([
-                f'windows-{OLDEST_PYTHON}',
+                f'windows-{oldest_python}',
                 f'windows-{NEWEST_PYTHON}',
             ])
         if with_macos:
             required.extend([
-                f'macos-{OLDEST_PYTHON}',
+                f'macos-{oldest_python}',
                 f'macos-{NEWEST_PYTHON}',
             ])
         if with_pypy:
@@ -120,7 +122,7 @@ def set_branch_protection(
         if with_docs:
             required.append('ubuntu-docs')
     else:  # default for most packages
-        required.extend([OLDEST_PYTHON, NEWEST_PYTHON])
+        required.extend([oldest_python, NEWEST_PYTHON])
         if template != 'toolkit':
             required.append('coverage')
         if with_docs:

--- a/src/zope/meta/shared/packages.py
+++ b/src/zope/meta/shared/packages.py
@@ -153,9 +153,6 @@ def supported_python_versions(oldest_version=OLDEST_PYTHON_VERSION,
     containing all versions from oldest to newest that can be iterated over in
     the templates.
 
-    Args:
-        oldest_version (str): The oldest supported Python version, e.g. '3.8'.
-
     Kwargs:
         oldest_version (str):
             The oldest supported Python version, e.g. '3.8'.

--- a/src/zope/meta/shared/packages.py
+++ b/src/zope/meta/shared/packages.py
@@ -145,20 +145,26 @@ def parse_additional_config(cfg):
     return data
 
 
-def supported_python_versions(short_version=False):
+def supported_python_versions(oldest_version=OLDEST_PYTHON_VERSION,
+                              short_version=False):
     """Create a list containing all supported Python versions
 
     Uses the configured oldest and newest Python versions to compute a list
     containing all versions from oldest to newest that can be iterated over in
     the templates.
 
+    Args:
+        oldest_version (str): The oldest supported Python version, e.g. '3.8'.
+
     Kwargs:
+        oldest_version (str):
+            The oldest supported Python version, e.g. '3.8'.
 
         short_version (bool):
-            Return short versions like "313" instead of "3.13"
+            Return short versions like "313" instead of "3.13". Default False.
     """
     minor_versions = []
-    oldest_python = parse_version(OLDEST_PYTHON_VERSION)
+    oldest_python = parse_version(oldest_version)
     newest_python = parse_version(NEWEST_PYTHON_VERSION)
     for minor in range(oldest_python.minor, newest_python.minor + 1):
         minor_versions.append(minor)

--- a/src/zope/meta/update_python_support.py
+++ b/src/zope/meta/update_python_support.py
@@ -113,19 +113,19 @@ def main():
             sys.exit(0)
 
         if no_longer_supported:
-            for version in sorted(list(no_longer_supported)):
-                call(bin_dir / 'addchangelogentry',
-                     f'Drop support for Python {version}.',
-                     *non_interactive_params)
+            version_spec = ', '.join(sorted(no_longer_supported))
+            call(bin_dir / 'addchangelogentry',
+                 f'Drop support for Python {version_spec}.',
+                 *non_interactive_params)
             python_versions_args.append(
                 '--drop=' + ','.join(no_longer_supported))
 
         if not_yet_supported:
-            for version in sorted(list(not_yet_supported)):
-                call(
-                    bin_dir / 'addchangelogentry',
-                    f'Add support for Python {version}.',
-                    *non_interactive_params)
+            version_spec = ', '.join(sorted(not_yet_supported))
+            call(
+                bin_dir / 'addchangelogentry',
+                f'Add support for Python {version_spec}.',
+                *non_interactive_params)
             python_versions_args = [
                 '--add=' +
                 ','.join(supported_python_versions(oldest_python_version))
@@ -138,8 +138,7 @@ def main():
             call(os.environ['EDITOR'], '.meta.toml')
 
             config_package_args = [
-                sys.executable,
-                'config-package.py',
+                bin_dir / 'config-package',
                 path,
                 f'--branch={branch_name}',
                 '--no-push',


### PR DESCRIPTION
This PR adds support for a new command line parameter `--oldest-python` and a corresponding value in `.meta.toml` that allows setting a minimum supported Python version that may be different from the previously hardcoded default.