### PR TITLE
Fix branch protection min version.

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [meta]
 template = "pure-python"
-commit-id = "35d10997"
+commit-id = "7565cacd"
 
 [python]
 with-windows = false
@@ -16,7 +16,7 @@ with-macos = false
 use-flake8 = true
 
 [coverage]
-fail-under = 20
+fail-under = 18
 
 [coverage-run]
 source = "zope.meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 
 [build-system]
-requires = ["setuptools<74"]
+requires = ["setuptools < 74"]
 build-backend = "setuptools.build_meta"
 
 [tool.coverage.run]
@@ -11,7 +11,7 @@ branch = true
 source = ["zope.meta"]
 
 [tool.coverage.report]
-fail_under = 20
+fail_under = 18
 precision = 2
 ignore_errors = true
 show_missing = true

--- a/src/zope/meta/set_branch_protection_rules.py
+++ b/src/zope/meta/set_branch_protection_rules.py
@@ -72,7 +72,7 @@ def set_branch_protection(
     with_pypy = meta_toml['python']['with-pypy']
     oldest_python_version = meta_toml['python'].get('oldest-python',
                                                     OLDEST_PYTHON_VERSION)
-    oldest_python = oldest_python_version.replace('.', '')
+    oldest_python = f"py{oldest_python_version.replace('.', '')}"
     with_windows = meta_toml['python']['with-windows']
     with_macos = meta_toml['python']['with-macos']
     required = ['linting']

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ usedevelop = true
 package = wheel
 wheel_build_env = .pkg
 deps =
-    setuptools  <74
+    setuptools < 74
 commands =
     zope-testrunner --test-path=src {posargs:-vc}
 extras =
@@ -35,7 +35,7 @@ description = ensure that the distribution is ready to release
 basepython = python3
 skip_install = true
 deps =
-    setuptools <74
+    setuptools < 74
     twine
     build
     check-manifest


### PR DESCRIPTION
It has to to start with `py` like `NEWEST_PYTHON`.

Used in https://github.com/zopefoundation/zc.recipe.testrunner/pull/18
