### PR TITLE
Retire Python 3.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,6 @@ jobs:
         config:
         # [Python version, tox env]
         - ["3.11", "release-check"]
-        - ["3.8", "py38"]
         - ["3.9", "py39"]
         - ["3.10", "py310"]
         - ["3.11", "py311"]

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [meta]
 template = "pure-python"
-commit-id = "7565cacd"
+commit-id = "96809911"
 
 [python]
 with-windows = false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     rev: v3.19.0
     hooks:
     - id: pyupgrade
-      args: [--py38-plus]
+      args: [--py39-plus]
   - repo: https://github.com/isidentical/teyit
     rev: 0.4.3
     hooks:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Change log
 1.1 (unreleased)
 ----------------
 
+- Drop support for Python 3.8.
+
 - Allow specifying a minimum supported Python version other than the previously
   hardcoded default of Python 3.8.
 

--- a/docs/narr.rst
+++ b/docs/narr.rst
@@ -178,7 +178,7 @@ The following options are only needed one time as their values are stored in
 
 --oldest-python
   The oldest version of Python supported by this package. Specified as version
-  number, e.g. ``3.8``. This setting is optional and defaults to the lowest
+  number, e.g. ``3.12``. This setting is optional and defaults to the lowest
   Python version generally supported by zopefoundation packages.
 
 --with-docs
@@ -300,7 +300,7 @@ updated. Example:
         "  image: postgres",
         ]
     additional-config = [
-        "- [\"3.8\",   \"py38-slim\"]",
+        "- [\"3.12\",   \"py312-slim\"]",
         ]
     additional-exclude = [
         "- { os: windows, config: [\"pypy-3.10\", \"pypy3\"] }",

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
         'License :: OSI Approved :: Zope Public License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
@@ -75,7 +74,7 @@ setup(
         'tox',
         'zest.releaser',
     ],
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     include_package_data=True,
     zip_safe=False,
     extras_require={

--- a/src/zope/meta/c-code/tests.yml.j2
+++ b/src/zope/meta/c-code/tests.yml.j2
@@ -29,7 +29,7 @@
 # native support. It works, but is slow.
 #
 # Another major downside: You can't just re-run the job for one part
-# of the matrix. So if there's a transient test failure that hit, say, 3.8,
+# of the matrix. So if there's a transient test failure that hit, say, 3.11,
 # to get a clean run every version of Python runs again. That's bad.
 # https://github.community/t/ability-to-rerun-just-a-single-job-in-a-workflow/17234/65
 

--- a/src/zope/meta/shared/packages.py
+++ b/src/zope/meta/shared/packages.py
@@ -20,7 +20,7 @@ from packaging.version import parse as parse_version
 TYPES = ['buildout-recipe', 'c-code', 'pure-python', 'zope-product', 'toolkit']
 ORG = 'zopefoundation'
 BASE_PATH = pathlib.Path(__file__).parent.parent
-OLDEST_PYTHON_VERSION = '3.8'
+OLDEST_PYTHON_VERSION = '3.9'
 NEWEST_PYTHON_VERSION = '3.13'
 FUTURE_PYTHON_VERSION = '3.14'
 PYPY_VERSION = '3.10'
@@ -155,7 +155,7 @@ def supported_python_versions(oldest_version=OLDEST_PYTHON_VERSION,
 
     Kwargs:
         oldest_version (str):
-            The oldest supported Python version, e.g. '3.8'.
+            The oldest supported Python version, e.g. '3.9'.
 
         short_version (bool):
             Return short versions like "313" instead of "3.13". Default False.

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ minversion = 3.18
 envlist =
     release-check
     lint
-    py38
     py39
     py310
     py311


### PR DESCRIPTION
This PR sets Python 3.9 as the oldest supported Python version and it removes Python 3.8 support from this package as well.

- Python 3.8 has been EOL for more than two months, see https://devguide.python.org/versions/
- The upcoming Plone 6.1 sets an even higher minimum supported version (3.10)
- zc.buildout really wants to drop it as well, see https://github.com/buildout/buildout/pull/671
- In Zope the list of custom version pins to keep Python 3.8 support gets longer and longer, this is an unnecessary maintenance burden.
