### PR TITLE
Add `omit` option to `coverage-run` configuration.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ Change log
 
 - Allow ``setuptools <= 75.6.0``.
 
+- Add ``omit`` option to ``coverage-run`` configuration because when defined in
+  ``pyproject.toml`` it needs to be a list of strings.
+
 1.0 (2024-10-02)
 ----------------
 

--- a/docs/narr.rst
+++ b/docs/narr.rst
@@ -217,9 +217,11 @@ updated. Example:
 
     [coverage-run]
     additional-config = [
-        "omit =",
-        "    src/foo/bar.py",
-        ]
+        "data_file = $COVERAGE_HOME.coverage",
+    ]
+    omit = [
+        "src/foo/bar.py",
+    ]
     source = "src"
 
     [tox]
@@ -406,6 +408,10 @@ The corresponding section is named: ``[coverage-run]``.
 additional-config
   Additional options for the ``[run]`` section of the coverage configuration.
   This option has to be a list of strings.
+
+omit
+  Files to be omitted from the coverage report. This option has to
+  be a list of strings. It defaults to an empty list.
 
 source
   This option defines the value of ``source`` in the coverage ``[run]``

--- a/src/zope/meta/config_package.py
+++ b/src/zope/meta/config_package.py
@@ -457,8 +457,6 @@ class PackageConfiguration:
         coverage_additional = self.tox_option('coverage-additional')
         testenv_deps = self.tox_option('testenv-deps')
         coverage_setenv = self.tox_option('coverage-setenv')
-        coverage_run_additional_config = self.meta_cfg['coverage-run'].get(
-            'additional-config', [])
         flake8_additional_sources = self.meta_cfg['flake8'].get(
             'additional-sources', '')
         if flake8_additional_sources:
@@ -481,7 +479,6 @@ class PackageConfiguration:
             coverage_basepython=coverage_basepython,
             coverage_command=coverage_command,
             coverage_run_source=self.coverage_run_source,
-            coverage_run_additional_config=coverage_run_additional_config,
             coverage_setenv=coverage_setenv,
             coverage_fail_under=self.coverage_fail_under,
             flake8_additional_sources=flake8_additional_sources,
@@ -615,6 +612,9 @@ class PackageConfiguration:
         add_cfg = self.meta_cfg['coverage-run'].get('additional-config', [])
         for key, value in parse_additional_config(add_cfg).items():
             coverage['run'][key] = value
+        omit = self.meta_cfg['coverage-run'].get('omit', [])
+        if omit:
+            coverage['run']['omit'] = omit
 
         # Remove empty sections
         toml_data = {k: v for k, v in toml_data.items() if v}


### PR DESCRIPTION
This is needed when this configuration is defined in `pyproject.toml` as there it needs to be a list of strings.

Removed unused config variables for `tox.ini`.

This is needed for https://github.com/zopefoundation/zdaemon/pull/37