### PR TITLE
Use uv in GitHub Actions.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,33 +39,24 @@ jobs:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
-    - name: Set up Python
-      uses: actions/setup-python@v5
+    - name: Install uv + caching
+      uses: astral-sh/setup-uv@v5
       with:
-        python-version: ${{ matrix.config[0] }}
-        allow-prereleases: true
-    - name: Pip cache
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{ matrix.config[0] }}-
-          ${{ runner.os }}-pip-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install tox
+        enable-cache: true
+        cache-dependency-glob: |
+          setup.*
+          tox.ini
+        python-version: ${{ matrix.matrix.config[0] }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Test
       if: ${{ !startsWith(runner.os, 'Mac') }}
-      run: tox -e ${{ matrix.config[1] }}
+      run: uvx --with tox-uv tox -e ${{ matrix.config[1] }}
     - name: Test (macOS)
       if: ${{ startsWith(runner.os, 'Mac') }}
-      run: tox -e ${{ matrix.config[1] }}-universal2
+      run: uvx --with tox-uv tox -e ${{ matrix.config[1] }}-universal2
     - name: Coverage
       if: matrix.config[1] == 'coverage'
       run: |
-        pip install coveralls
-        coveralls --service=github
+        uvx coveralls --service=github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [meta]
 template = "pure-python"
-commit-id = "0754ed06"
+commit-id = "eb106542"
 
 [python]
 with-windows = false

--- a/src/zope/meta/default/tests.yml.j2
+++ b/src/zope/meta/default/tests.yml.j2
@@ -92,26 +92,15 @@ jobs:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
-    - name: Set up Python
-      uses: actions/setup-python@v5
+    - name: Install uv + caching
+      uses: astral-sh/setup-uv@v5
       with:
-        python-version: ${{ matrix.config[0] }}
-        allow-prereleases: true
-    - name: Pip cache
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{ matrix.config[0] }}-
-          ${{ runner.os }}-pip-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install tox
-{% for line in gha_additional_install %}
-        %(line)s
-{% endfor %}
+        enable-cache: true
+        cache-dependency-glob: |
+          setup.*
+          tox.ini
+        python-version: ${{ matrix.matrix.config[0] }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Test
       if: ${{ !startsWith(runner.os, 'Mac') }}
 {% if gha_test_environment %}
@@ -126,7 +115,7 @@ jobs:
         %(line)s
       {% endfor %}
 {% else %}
-      run: tox -e ${{ matrix.config[1] }}
+      run: uvx --with tox-uv tox -e ${{ matrix.config[1] }}
 {% endif %}
     - name: Test (macOS)
       if: ${{ startsWith(runner.os, 'Mac') }}
@@ -136,11 +125,10 @@ jobs:
         %(line)s
       {% endfor %}
 {% endif %}
-      run: tox -e ${{ matrix.config[1] }}-universal2
+      run: uvx --with tox-uv tox -e ${{ matrix.config[1] }}-universal2
     - name: Coverage
       if: matrix.config[1] == 'coverage'
       run: |
-        pip install coveralls
-        coveralls --service=github
+        uvx coveralls --service=github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #289.

It does not plainly use the things suggested in the blog post referenced in #289 but the successor provided by uv itself.

Used:

* here in this PR
* https://github.com/zopefoundation/zope.annotation/pull/27
* https://github.com/zopefoundation/zope.exceptions/pull/38
* https://github.com/zopefoundation/zope.testing/pull/50

Sorry for the noise in some of the PRs, they were just not up to date. Maybe we need something here to keep packages automatically up to date.