### PR TITLE
Add `pyupgrade-exclude` to `[pre-commit]` section in `.meta.toml`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Change log
 - Add script ``bin/switch-to-pep420`` to convert a package from the old
   namespace package layout to the new PEP 420 native layout.
 
+- Add ``pyupgrade-exclude`` to ``[pre-commit]`` section in ``.meta.toml``.
 
 1.1 (2025-01-29)
 ----------------

--- a/docs/narr.rst
+++ b/docs/narr.rst
@@ -352,6 +352,8 @@ updated. Example:
 
     [pre-commit]
     teyit-exclude = "App/tests/fixtures/error\.py"
+    pyupgrade-exclude = "^src/zope/proxy/__init__\.py$"
+
 
     [readthedocs]
     build-extra = [
@@ -659,6 +661,10 @@ teyit-exclude
   Regex for files to be hidden from teyit. It fails on files containing syntax
   errors. This option has to be a string and is omitted when not defined.
 
+pyupgrade-exclude
+  Regex for files to be hidden from pyupgrade. It might be a bit overly
+  optimistic with its changes. This option has to be a string and is omitted
+  when not defined.
 
 ReadTheDocs options
 ```````````````````

--- a/src/zope/meta/config_package.py
+++ b/src/zope/meta/config_package.py
@@ -381,6 +381,8 @@ class PackageConfiguration:
 
     def pre_commit_config_yaml(self):
         teyit_exclude = self.meta_cfg["pre-commit"].get("teyit-exclude", "")
+        pyupgrade_exclude = self.meta_cfg["pre-commit"].get(
+            "pyupgrade-exclude", "")
 
         self.copy_with_meta(
             "pre-commit-config.yaml.j2",
@@ -388,6 +390,7 @@ class PackageConfiguration:
             self.config_type,
             oldest_python_version=self.oldest_python.replace(".", ""),
             teyit_exclude=teyit_exclude,
+            pyupgrade_exclude=pyupgrade_exclude,
         )
 
     def readthedocs(self):

--- a/src/zope/meta/default/pre-commit-config.yaml.j2
+++ b/src/zope/meta/default/pre-commit-config.yaml.j2
@@ -14,6 +14,9 @@ repos:
     hooks:
     - id: pyupgrade
       args: [--py%(oldest_python_version)s-plus]
+{% if pyupgrade_exclude %}
+      exclude: %(pyupgrade_exclude)s
+{% endif %}
   - repo: https://github.com/isidentical/teyit
     rev: 0.4.3
     hooks:


### PR DESCRIPTION
Used in https://github.com/zopefoundation/zope.proxy/pull/74