### PR TITLE
Add release-check step for c-code templates (and more)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Change log
 1.2 (unreleased)
 ----------------
 
+- Fixes for changed wheel name issues with the latest setuptools/pip
+
+- Improve ``pyproject.toml`` generation
+
+- Add the tox ``release-check`` step to the ``c-code`` templates
+
 - Add script ``bin/switch-to-pep420`` to convert a package from the old
   namespace package layout to the new PEP 420 native layout.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Change log
 1.2 (unreleased)
 ----------------
 
+- Retire configuration ``require-cffi``.
+  Build dependencies should go into ``pyproject.toml`` instead.
+
 - Fixes for changed wheel name issues with the latest setuptools/pip
 
 - Improve ``pyproject.toml`` generation

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Change log
 1.2 (unreleased)
 ----------------
 
-- Retire configuration ``require-cffi``.
+- Retire configurations ``require-cffi`` and ``additional-build-requirement``.
   Build dependencies should go into ``pyproject.toml`` instead.
 
 - Fixes for changed wheel name issues with the latest setuptools/pip

--- a/docs/narr.rst
+++ b/docs/narr.rst
@@ -594,12 +594,6 @@ additional-install
   For the template ``c-code`` this option is currently used to replace how to
   install the package itself and run tests and coverage.
 
-additional-build-dependencies
-  Additional Python packages to install into the virtual environment before
-  building a package with C extensions. This is used for the ``c-code``
-  template to work around issues on macOS where setuptools attempts to retrieve
-  wheels and convert them to eggs multiple times.
-
 test-environment
   Environment variables to be set during the test run. This option has to be a
   list of strings.

--- a/docs/narr.rst
+++ b/docs/narr.rst
@@ -337,7 +337,6 @@ updated. Example:
         "\"${PYBIN}/tox\" -e py",
         "cd ..",
         ]
-    require-cffi = true
 
     [zest-releaser]
     options = [
@@ -624,11 +623,6 @@ manylinux-aarch64-tests
   Replacement for the tests against the aarch64 architecture. This option has
   to be a list of strings and defaults to testing using ``tox`` against all
   supported Python versions, which could be too slow for some packages.
-
-require-cffi
-  Require to install ``cffi`` via pip before trying to build the package. This
-  is needed for some packages to circumvent build problems on MacOS. This
-  option has to be a boolean (true or false).
 
 
 zest.releaser options

--- a/src/zope/meta/c-code/tests.yml.j2
+++ b/src/zope/meta/c-code/tests.yml.j2
@@ -258,7 +258,8 @@ jobs:
           # Unzip into src/ so that testrunner can find the .so files
           # when we ask it to load tests from that directory. This
           # might also save some build time?
-          unzip -n dist/%(package_name)s-*whl -d src
+          ls -l dist/
+          unzip -n dist/*.whl -d src
           # Use "--pre" here because dependencies with support for this future
           # Python release may only be available as pre-releases
           pip install --pre -e .[test]
@@ -274,7 +275,8 @@ jobs:
           # Unzip into src/ so that testrunner can find the .so files
           # when we ask it to load tests from that directory. This
           # might also save some build time?
-          unzip -n dist/%(package_name)s-*whl -d src
+          ls -l dist/
+          unzip -n dist/*.whl -d src
           pip install -e .[test]
       - name: Run tests with C extensions
         if: ${{ !startsWith(matrix.python-version, 'pypy') }}
@@ -335,7 +337,7 @@ jobs:
         run: |
           pip install -U wheel
           pip install -U coverage[toml]
-          pip install -U  "`ls dist/%(package_name)s-*.whl`[docs]"
+          pip install -U  "`ls dist/*.whl`[docs]"
       - name: Build docs
         env:
           ZOPE_INTERFACE_STRICT_IRO: 1
@@ -364,12 +366,12 @@ jobs:
 {% if require_cffi %}
           pip install -U 'cffi; platform_python_implementation == "CPython"'
 {% endif %}
-          pip install -U  "`ls dist/%(package_name)s-*.whl`[docs]"
+          pip install -U  "`ls dist/*.whl`[docs]"
       - name: Run release check
         env:
           ZOPE_INTERFACE_STRICT_IRO: 1
         run: |
-          tox -erelease-check
+          tox -e release-check
 
   manylinux:
     runs-on: ubuntu-latest

--- a/src/zope/meta/c-code/tests.yml.j2
+++ b/src/zope/meta/c-code/tests.yml.j2
@@ -346,6 +346,31 @@ jobs:
   {% endif %}
 {% endif %}
 
+  release-check:
+    needs: build-package
+    runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        python-version: ["%(manylinux_python_version)s"]
+        os: [ubuntu-latest]
+
+    steps:
+{% include 'tests-cache.j2' %}
+{% include 'tests-download.j2' %}
+      - name: Install %(package_name)s
+        run: |
+          pip install -U wheel
+          pip install -U tox
+{% if require_cffi %}
+          pip install -U 'cffi; platform_python_implementation == "CPython"'
+{% endif %}
+          pip install -U  "`ls dist/%(package_name)s-*.whl`[docs]"
+      - name: Run release check
+        env:
+          ZOPE_INTERFACE_STRICT_IRO: 1
+        run: |
+          tox -erelease-check
+
   manylinux:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name

--- a/src/zope/meta/c-code/tests.yml.j2
+++ b/src/zope/meta/c-code/tests.yml.j2
@@ -110,11 +110,6 @@ jobs:
         run: |
           pip install -U pip
           pip install -U "setuptools %(setuptools_version_spec)s" wheel twine
-{% if gha_additional_build_deps %}
-  {% for line in gha_additional_build_deps %}
-          pip install -U %(line)s
-  {% endfor %}
-{% endif %}
 
 {% for kind in ('macOS x86_64', 'macOS arm64', 'all other versions') %}
       - name: Build %(package_name)s (%(kind)s)

--- a/src/zope/meta/c-code/tests.yml.j2
+++ b/src/zope/meta/c-code/tests.yml.j2
@@ -101,9 +101,6 @@ jobs:
         if: matrix.python-version == '%(future_python_version)s'
         run: |
           pip install -U pip
-  {% if require_cffi %}
-          pip install -U --pre cffi
-  {% endif %}
           pip install -U "setuptools %(setuptools_version_spec)s" wheel twine
 {% endif %}
       - name: Install Build Dependencies
@@ -113,9 +110,6 @@ jobs:
         run: |
           pip install -U pip
           pip install -U "setuptools %(setuptools_version_spec)s" wheel twine
-  {% if require_cffi %}
-          pip install cffi
-  {% endif %}
 {% if gha_additional_build_deps %}
   {% for line in gha_additional_build_deps %}
           pip install -U %(line)s
@@ -248,9 +242,6 @@ jobs:
       - name: Install %(package_name)s ${{ matrix.python-version }}
         if: matrix.python-version == '%(future_python_version)s'
         run: |
-  {% if require_cffi %}
-          pip install -U --pre cffi
-  {%  endif %}
           pip install -U wheel "setuptools %(setuptools_version_spec)s"
           # coverage might have a wheel on PyPI for a future python version which is
           # not ABI compatible with the current one, so build it from sdist:
@@ -363,9 +354,6 @@ jobs:
         run: |
           pip install -U wheel
           pip install -U tox
-{% if require_cffi %}
-          pip install -U 'cffi; platform_python_implementation == "CPython"'
-{% endif %}
           pip install -U  "`ls dist/*.whl`[docs]"
       - name: Run release check
         env:

--- a/src/zope/meta/c-code/tox.ini.j2
+++ b/src/zope/meta/c-code/tox.ini.j2
@@ -5,6 +5,7 @@
 [tox]
 minversion = 4.0
 envlist =
+    release-check
     lint
 {% for py_version in supported_python_versions %}
     py%(py_version)s,py%(py_version)s-pure

--- a/src/zope/meta/config_package.py
+++ b/src/zope/meta/config_package.py
@@ -535,8 +535,6 @@ class PackageConfiguration:
             'additional-build-dependencies')
         gha_test_environment = self.gh_option('test-environment')
         gha_test_commands = self.gh_option('test-commands')
-        require_cffi = self.meta_cfg.get(
-            'c-code', {}).get('require-cffi', False)
         py_version_matrix = [
             x for x in zip(supported_python_versions(self.oldest_python,
                                                      short_version=False),
@@ -559,7 +557,6 @@ class PackageConfiguration:
             with_sphinx_doctests=self.with_sphinx_doctests,
             with_future_python=self.with_future_python,
             future_python_version=FUTURE_PYTHON_VERSION,
-            require_cffi=require_cffi,
             with_pypy=self.with_pypy,
             with_macos=self.with_macos,
             with_windows=self.with_windows,

--- a/src/zope/meta/config_package.py
+++ b/src/zope/meta/config_package.py
@@ -37,6 +37,7 @@ from .shared.packages import NEWEST_PYTHON_VERSION
 from .shared.packages import OLDEST_PYTHON_VERSION
 from .shared.packages import PYPY_VERSION
 from .shared.packages import SETUPTOOLS_VERSION_SPEC
+from .shared.packages import get_pyproject_toml
 from .shared.packages import get_pyproject_toml_defaults
 from .shared.packages import parse_additional_config
 from .shared.packages import supported_python_versions
@@ -460,6 +461,8 @@ class PackageConfiguration:
         return self.cfg_option('github-actions', name, default)
 
     def tox(self):
+        toml_doc = get_pyproject_toml(self.path / 'pyproject.toml')
+        build_requirements = toml_doc['build-system'].get('requires', [])
         additional_envlist = self.tox_option('additional-envlist')
         testenv_additional = self.tox_option('testenv-additional')
         testenv_additional_extras = self.tox_option(
@@ -519,6 +522,7 @@ class PackageConfiguration:
             future_python_shortversion=FUTURE_PYTHON_SHORTVERSION,
             supported_python_versions=supported_python_versions(
                 self.oldest_python, short_version=True),
+            build_requirements=build_requirements,
         )
 
     def tests_yml(self):
@@ -602,21 +606,13 @@ class PackageConfiguration:
     def pyproject_toml(self):
         """Modify pyproject.toml with meta options."""
         toml_path = self.path / 'pyproject.toml'
-
-        if toml_path.exists():
-            with open(toml_path, 'rb') as fp:
-                toml_doc = tomlkit.load(fp)
-        else:
-            toml_doc = tomlkit.document()
-            preamble = f'\n{META_HINT.format(config_type=self.config_type)}'
-            toml_doc.add(tomlkit.comment(preamble))
-        toml_data = collections.defaultdict(dict, **toml_doc)
+        toml_doc = get_pyproject_toml(toml_path)
 
         # Capture some pre-transformation data
-        old_requires = toml_data['build-system'].get('requires', [])
+        old_requires = toml_doc.get('build-system', {}).get('requires', [])
 
         # Apply template-dependent defaults
-        toml_data.update(get_pyproject_toml_defaults(self.config_type))
+        toml_doc.update(get_pyproject_toml_defaults(self.config_type))
 
         # Create or update section "build-system"
         if old_requires:
@@ -624,10 +620,10 @@ class PackageConfiguration:
                 x for x in old_requires if x.startswith('setuptools')]
             for setuptools_req in setuptools_requirement:
                 old_requires.remove(setuptools_req)
-            toml_data['build-system']['requires'].extend(old_requires)
+            toml_doc['build-system']['requires'].extend(old_requires)
 
         # Update coverage-related data
-        coverage = toml_data['tool']['coverage']
+        coverage = toml_doc['tool']['coverage']
         coverage['run']['source'] = self.coverage_run_source.split()
         coverage['report']['fail_under'] = self.coverage_fail_under
         add_cfg = self.meta_cfg['coverage-run'].get('additional-config', [])
@@ -638,10 +634,22 @@ class PackageConfiguration:
             coverage['run']['omit'] = omit
 
         # Remove empty sections
-        toml_data = {k: v for k, v in toml_data.items() if v}
+        for key, value in toml_doc.items():
+            if not value:
+                toml_doc.remove(key)
 
-        # Update and write out the document
-        toml_doc.update(toml_data)
+        # Add preamble if it is not already there
+        preamble = f'\n{META_HINT.format(config_type=self.config_type)}'
+        if preamble not in toml_doc.as_string():
+            toml_doc.add(tomlkit.comment(preamble))
+
+        # Fix formatting for some items, especially long lists, so diffs
+        # become readable.
+        toml_doc['build-system']['requires'].multiline(True)
+        toml_doc['tool']['coverage']['report']['exclude_lines'].multiline(True)
+        if toml_doc['tool']['coverage'].get('paths'):
+            toml_doc['tool']['coverage']['paths']['source'].multiline(True)
+
         with open(toml_path, 'w') as fp:
             tomlkit.dump(toml_doc, fp, sort_keys=True)
 

--- a/src/zope/meta/config_package.py
+++ b/src/zope/meta/config_package.py
@@ -531,8 +531,6 @@ class PackageConfiguration:
         gha_additional_exclude = self.gh_option('additional-exclude')
         gha_steps_before_checkout = self.gh_option('steps-before-checkout')
         gha_additional_install = self.gh_option('additional-install')
-        gha_additional_build_deps = self.gh_option(
-            'additional-build-dependencies')
         gha_test_environment = self.gh_option('test-environment')
         gha_test_commands = self.gh_option('test-commands')
         py_version_matrix = [
@@ -548,7 +546,6 @@ class PackageConfiguration:
             gha_additional_config=gha_additional_config,
             gha_additional_exclude=gha_additional_exclude,
             gha_additional_install=gha_additional_install,
-            gha_additional_build_deps=gha_additional_build_deps,
             gha_test_environment=gha_test_environment,
             gha_test_commands=gha_test_commands,
             gha_services=gha_services,

--- a/src/zope/meta/config_package.py
+++ b/src/zope/meta/config_package.py
@@ -470,8 +470,6 @@ class PackageConfiguration:
         testenv_commands_pre = self.tox_option('testenv-commands-pre')
         testenv_commands = self.tox_option('testenv-commands')
         testenv_setenv = self.tox_option('testenv-setenv')
-        require_cffi = self.meta_cfg.get(
-            'c-code', {}).get('require-cffi', False)
         coverage_basepython = self.tox_option(
             'coverage-basepython', default='python3')
         coverage_command = self.tox_option('coverage-command')
@@ -512,7 +510,6 @@ class PackageConfiguration:
             testenv_commands_pre=testenv_commands_pre,
             testenv_deps=testenv_deps,
             testenv_setenv=testenv_setenv,
-            require_cffi=require_cffi,
             with_docs=self.with_docs,
             with_future_python=self.with_future_python,
             with_pypy=self.with_pypy,

--- a/src/zope/meta/config_package.py
+++ b/src/zope/meta/config_package.py
@@ -467,6 +467,8 @@ class PackageConfiguration:
         testenv_commands_pre = self.tox_option('testenv-commands-pre')
         testenv_commands = self.tox_option('testenv-commands')
         testenv_setenv = self.tox_option('testenv-setenv')
+        require_cffi = self.meta_cfg.get(
+            'c-code', {}).get('require-cffi', False)
         coverage_basepython = self.tox_option(
             'coverage-basepython', default='python3')
         coverage_command = self.tox_option('coverage-command')
@@ -507,6 +509,7 @@ class PackageConfiguration:
             testenv_commands_pre=testenv_commands_pre,
             testenv_deps=testenv_deps,
             testenv_setenv=testenv_setenv,
+            require_cffi=require_cffi,
             with_docs=self.with_docs,
             with_future_python=self.with_future_python,
             with_pypy=self.with_pypy,

--- a/src/zope/meta/default/tox-release-check.j2
+++ b/src/zope/meta/default/tox-release-check.j2
@@ -3,15 +3,14 @@ description = ensure that the distribution is ready to release
 basepython = python3
 skip_install = true
 deps =
-    setuptools %(setuptools_version_spec)s
+{% for build_requirement in build_requirements %}
+    %(build_requirement)s
+{% endfor %}
     twine
     build
     check-manifest
     check-python-versions >= 0.20.0
     wheel
-{% if require_cffi %}
-    cffi; platform_python_implementation == "CPython"
-{% endif %}
 commands_pre =
 commands =
     check-manifest

--- a/src/zope/meta/default/tox-release-check.j2
+++ b/src/zope/meta/default/tox-release-check.j2
@@ -9,6 +9,9 @@ deps =
     check-manifest
     check-python-versions >= 0.20.0
     wheel
+{% if require_cffi %}
+    cffi; platform_python_implementation == "CPython"
+{% endif %}
 commands_pre =
 commands =
     check-manifest

--- a/src/zope/meta/shared/packages.py
+++ b/src/zope/meta/shared/packages.py
@@ -110,7 +110,7 @@ def get_pyproject_toml(path: pathlib.Path) -> TOMLDocument:
     else:
         toml_doc = TOMLDocument()
 
-    #return collections.defaultdict(dict, **toml_doc)
+    # return collections.defaultdict(dict, **toml_doc)
     return toml_doc
 
 

--- a/src/zope/meta/shared/packages.py
+++ b/src/zope/meta/shared/packages.py
@@ -10,7 +10,6 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
-import collections
 import configparser
 import itertools
 import pathlib
@@ -110,7 +109,6 @@ def get_pyproject_toml(path: pathlib.Path) -> TOMLDocument:
     else:
         toml_doc = TOMLDocument()
 
-    # return collections.defaultdict(dict, **toml_doc)
     return toml_doc
 
 

--- a/src/zope/meta/shared/packages.py
+++ b/src/zope/meta/shared/packages.py
@@ -10,11 +10,14 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
+import collections
 import configparser
 import itertools
 import pathlib
 
+import tomlkit
 from packaging.version import parse as parse_version
+from tomlkit.toml_document import TOMLDocument
 
 
 TYPES = ['buildout-recipe', 'c-code', 'pure-python', 'zope-product', 'toolkit']
@@ -96,7 +99,22 @@ PYPROJECT_TOML_OVERRIDES = {
 }
 
 
-def get_pyproject_toml_defaults(template_name):
+def get_pyproject_toml(path: pathlib.Path) -> TOMLDocument:
+    """Parse ``pyproject.toml`` and return its values as ``TOMLDocument``.
+
+    ``path`` must point to a pyproject.toml file.
+    """
+    if path.exists():
+        with open(path, 'rb') as fp:
+            toml_doc = tomlkit.load(fp)
+    else:
+        toml_doc = TOMLDocument()
+
+    #return collections.defaultdict(dict, **toml_doc)
+    return toml_doc
+
+
+def get_pyproject_toml_defaults(template_name: str) -> dict:
     """ Get pyproject.toml default data for a given template name"""
     return merge_dicts(PYPROJECT_TOML_DEFAULTS,
                        PYPROJECT_TOML_OVERRIDES.get(template_name, {}))


### PR DESCRIPTION
The `c-code` tox template was missing the `release-check` step, even though it was defined in the template. Also, the check was never run on GHA.

Noticed it today working on `persistent` where the `release-check` step fails because it wasn't tested as part of `tox -pauto` and the GHA configuration never tested it, either.

This PR also works around wheel name change issues with the latest setuptools/pip and improves formatting for the generated ``pyproject.toml`` file.

It also retires the configuration variables ``require-cffi`` in the ``[c-code]`` section and ``additional-build-dependencies`` in the ``[github-actions]`` section. Packages required for building a package (meaning installed before setup.py is run) should go into pyproject.toml's ``requires`` list in the ``[build-system]`` section instead. I have open PRs for all packages that used these variables which apply these changed templates and clean up their configuration.