### PR TITLE
Add argument ``--no-tests`` to configuration script to skip unit tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Change log
 1.2 (unreleased)
 ----------------
 
+- Add argument ``--no-tests`` to configuration script to skip unit tests.
+  Useful for quick iterative configuration or code changes.
+
 - Retire configurations ``require-cffi`` and ``additional-build-requirement``.
   Build dependencies should go into ``pyproject.toml`` instead.
 

--- a/docs/narr.rst
+++ b/docs/narr.rst
@@ -151,6 +151,10 @@ The following arguments are supported.
 --no-push
   Avoid pushing at the end of the configuration run.
 
+--no-tests
+  Don't run the package's unit tests as part of the configuration run. Useful
+  for quickly testing iterative configuration changes.
+
 --branch
   Define a specific git branch name to be created for the changes. By default
   the script creates one which includes the name of the configuration type.

--- a/src/zope/meta/config_package.py
+++ b/src/zope/meta/config_package.py
@@ -89,6 +89,12 @@ def handle_command_line_arguments():
         default=True,
         help='Prevent direct push.')
     parser.add_argument(
+        '--no-tests',
+        dest='run_tests',
+        action='store_false',
+        default=True,
+        help='Skip running unit tests.')
+    parser.add_argument(
         '--with-macos',
         dest='with_macos',
         action='store_true',
@@ -722,9 +728,10 @@ class PackageConfiguration:
                 meta_f.write('\n')
                 tomlkit.dump(meta_cfg, meta_f)
 
-            tox_path = shutil.which('tox') or (
-                pathlib.Path(cwd) / 'bin' / 'tox')
-            call(tox_path, '-p', 'auto')
+            if self.args.run_tests:
+                tox_path = shutil.which('tox') or (
+                    pathlib.Path(cwd) / 'bin' / 'tox')
+                call(tox_path, '-p', 'auto')
 
             updating = git_branch(self.branch_name)
 


### PR DESCRIPTION
When testing configuration changes or when making code changes to `zope.meta` itself the automatic unit test runs are a huge time drain. This PR adds a flag to skip them.