### PR TITLE
Add argument ``--template-overrides`` to enable template overrides

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Change log
 1.2 (unreleased)
 ----------------
 
+- Use Jinja templates to generate ``pyproject.toml`` files as well.
+
 - Add argument ``--template-overrides`` to configuration script to specify
   an additional configuration templates folder. This folder is expected to
   contain subfolders for each overridden configuration type or a ``default``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Change log
 1.2 (unreleased)
 ----------------
 
+- Add argument ``--template-overrides`` to configuration script to specify
+  an additional configuration templates folder. This folder is expected to
+  contain subfolders for each overridden configuration type or a ``default``
+  folder. The templates in these template folders will override the built-in
+  templates.
+
 - Add argument ``--no-tests`` to configuration script to skip unit tests.
   Useful for quick iterative configuration or code changes.
 

--- a/docs/narr.rst
+++ b/docs/narr.rst
@@ -166,6 +166,10 @@ The following options are only needed one time as their values are stored in
   Define the configuration type (see `Configuration types`_ section above) to
   be used for the repository.
 
+--template-overrides
+  Filesystem path to a folder that contains subfolders for configuration type
+  and default templates. Used to override built-in configuration templates.
+
 --with-macos
   Enable running the tests on macOS on GitHub Actions.
 

--- a/src/zope/meta/buildout-recipe/pyproject_defaults.toml.j2
+++ b/src/zope/meta/buildout-recipe/pyproject_defaults.toml.j2
@@ -1,0 +1,37 @@
+[build-system]
+requires = [
+    "setuptools %(setuptools_version_spec)s",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"
+
+[tool.coverage.run]
+branch = true
+source = ["%(coverage_run_source)s"]
+parallel = true
+
+[tool.coverage.report]
+fail_under = %(coverage_fail_under)s
+precision = 2
+ignore_errors = true
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "pragma: nocover",
+    "except ImportError:",
+    "raise NotImplementedError",
+    "if __name__ == '__main__':",
+    "self.fail",
+    "raise AssertionError",
+    "raise unittest.Skip",
+]
+
+[tool.coverage.html]
+directory = "parts/htmlcov"
+
+[tool.coverage.paths]
+source = [
+    "src/",
+    ".tox/*/lib/python*/site-packages/",
+    ".tox/pypy*/site-packages/",
+]

--- a/src/zope/meta/c-code/pyproject_defaults.toml.j2
+++ b/src/zope/meta/c-code/pyproject_defaults.toml.j2
@@ -1,0 +1,37 @@
+[build-system]
+requires = [
+    "setuptools %(setuptools_version_spec)s",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"
+
+[tool.coverage.run]
+branch = true
+source = ["%(coverage_run_source)s"]
+relative_files = true
+
+[tool.coverage.report]
+fail_under = %(coverage_fail_under)s
+precision = 2
+ignore_errors = true
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "pragma: nocover",
+    "except ImportError:",
+    "raise NotImplementedError",
+    "if __name__ == '__main__':",
+    "self.fail",
+    "raise AssertionError",
+    "raise unittest.Skip",
+]
+
+[tool.coverage.html]
+directory = "parts/htmlcov"
+
+[tool.coverage.paths]
+source = [
+    "src/",
+    ".tox/*/lib/python*/site-packages/",
+    ".tox/pypy*/site-packages/",
+]

--- a/src/zope/meta/default/pyproject_defaults.toml.j2
+++ b/src/zope/meta/default/pyproject_defaults.toml.j2
@@ -1,0 +1,29 @@
+[build-system]
+requires = [
+    "setuptools %(setuptools_version_spec)s",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"
+
+[tool.coverage.run]
+branch = true
+source = ["%(coverage_run_source)s"]
+
+[tool.coverage.report]
+fail_under = %(coverage_fail_under)s
+precision = 2
+ignore_errors = true
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "pragma: nocover",
+    "except ImportError:",
+    "raise NotImplementedError",
+    "if __name__ == '__main__':",
+    "self.fail",
+    "raise AssertionError",
+    "raise unittest.Skip",
+]
+
+[tool.coverage.html]
+directory = "parts/htmlcov"


### PR DESCRIPTION
The new argument takes a filesystem path that will be searched for the configuration type folders (and the `default` folder) before the built-in folders are searched for the template files. This allows overriding the built-in templates. I am using it to make using the package configuration script easier for my own and client repositories.