### PR TITLE
Bring back processing of GHA additional-install for the default template

### DIFF
--- a/src/zope/meta/default/tests.yml.j2
+++ b/src/zope/meta/default/tests.yml.j2
@@ -92,6 +92,13 @@ jobs:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
+{% if gha_additional_install %}
+    - name: Install additional dependencies
+      run: |
+{% for line in gha_additional_install %}
+        %(line)s
+  {% endfor %}
+{% endif %}
     - name: Install uv + caching
       uses: astral-sh/setup-uv@v5
       with:


### PR DESCRIPTION
It got remove in #307 and caused a problem for Products.ZMySQLDA (https://github.com/zopefoundation/Products.ZMySQLDA/issues/38)