### PR TITLE
Add ability to omit creating some optional files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Change log
 1.2 (unreleased)
 ----------------
 
+- Add ability to omit creating files by providing empty override templates.
+
 - Fixed a regression that removed GHA additional installs from the
   default template for GHA testing.
 

--- a/docs/narr.rst
+++ b/docs/narr.rst
@@ -169,6 +169,9 @@ The following options are only needed one time as their values are stored in
 --template-overrides
   Filesystem path to a folder that contains subfolders for configuration type
   and default templates. Used to override built-in configuration templates.
+  Empty override template files will prevent creating the respective file in
+  the repository you are managing with ``zope.meta``, this way you can
+  purposely omit creating some optional files.
 
 --with-macos
   Enable running the tests on macOS on GitHub Actions.

--- a/src/zope/meta/c-code/tox.ini.j2
+++ b/src/zope/meta/c-code/tox.ini.j2
@@ -1,4 +1,3 @@
-{% set with_coverage = True %}
 {% set raw_testenv_setenv = testenv_setenv %}
 {% set testenv_setenv = ['pure: PURE_PYTHON=1', '!pure-!pypy3: PURE_PYTHON=0'] + testenv_setenv %}
 {% set coverage_setenv = ['PURE_PYTHON=1'] + coverage_setenv %}
@@ -19,9 +18,7 @@ envlist =
 {% if with_docs %}
     docs
 {% endif %}
-{% if with_coverage %}
     coverage
-{% endif %}
 {% for line in additional_envlist %}
     %(line)s
 {% endfor %}

--- a/src/zope/meta/config_package.py
+++ b/src/zope/meta/config_package.py
@@ -629,7 +629,8 @@ class PackageConfiguration:
             self.copy_with_meta(
                 'MANIFEST.in.j2', self.path / 'MANIFEST.in', self.config_type,
                 manifest_additional_rules=manifest_additional_rules,
-                with_docs=self.with_docs)
+                with_docs=self.with_docs,
+                have_md_files=list(self.path.glob('*.md')))
 
     def pyproject_toml(self):
         """Modify pyproject.toml with meta options."""
@@ -698,8 +699,18 @@ class PackageConfiguration:
         """Copy the source file to destination and a hint of origin.
 
         If kwargs are given they are used as template arguments.
+
+        If the rendered template output is an empty string, don't write it
+        to disk. This allows package maintainers to prevent adding certain
+        optional files by specifying a custom templates path with the
+        ``--template-overrides`` option and adding an empty template there.
         """
         rendered = self.render_with_meta(template_name, config_type, **kw)
+
+        # If the rendered template is empty, give up and return.
+        if not rendered.strip():
+            return
+
         meta_hint = meta_hint.format(config_type=config_type)
         if rendered.startswith('#!'):
             she_bang, _, body = rendered.partition('\n')
@@ -732,15 +743,16 @@ class PackageConfiguration:
             'CONTRIBUTING.md', self.path / 'CONTRIBUTING.md', self.config_type,
             meta_hint=META_HINT_MARKDOWN)
 
-        with change_dir(self.path):
-            # We have to add it here otherwise the linter complains
-            # that it is not added.
-            early_add = [
-                '.pre-commit-config.yaml',
-                'CONTRIBUTING.md',
-                'pyproject.toml',
-            ]
-            if self.args.commit:
+        if self.args.commit:
+            with change_dir(self.path):
+                # We have to add it here otherwise the linter complains
+                # that it is not added.
+                early_add_candidates = (
+                    '.pre-commit-config.yaml',
+                    'pyproject.toml',
+                    'CONTRIBUTING.md')
+                early_add = [x for x in early_add_candidates
+                             if pathlib.Path(x).exists()]
                 call('git', 'add', *early_add)
 
         self.manylinux_sh()
@@ -758,7 +770,9 @@ class PackageConfiguration:
                 call('git', 'rm', '.coveragerc')
             if pathlib.Path('appveyor.yml').exists():
                 call('git', 'rm', 'appveyor.yml')
-            if self.with_docs and self.args.commit:
+            if self.with_docs and \
+               pathlib.Path('.readthedocs.yaml').exists() and \
+               self.args.commit:
                 call('git', 'add', '.readthedocs.yaml')
             if self.add_manylinux and self.args.commit:
                 call('git', 'add', '.manylinux.sh', '.manylinux-install.sh')

--- a/src/zope/meta/config_package.py
+++ b/src/zope/meta/config_package.py
@@ -630,7 +630,9 @@ class PackageConfiguration:
                 'MANIFEST.in.j2', self.path / 'MANIFEST.in', self.config_type,
                 manifest_additional_rules=manifest_additional_rules,
                 with_docs=self.with_docs,
-                have_md_files=list(self.path.glob('*.md')))
+                have_md_files=list(self.path.glob('*.md')),
+                have_docs_txt_files=list(self.path.glob('docs/*.txt')),
+                have_src_folder=(self.path / 'src').exists())
 
     def pyproject_toml(self):
         """Modify pyproject.toml with meta options."""

--- a/src/zope/meta/default/MANIFEST.in.j2
+++ b/src/zope/meta/default/MANIFEST.in.j2
@@ -10,11 +10,15 @@ include .pre-commit-config.yaml
 
 recursive-include docs *.py
 recursive-include docs *.rst
+{% if have_docs_txt_files %}
 recursive-include docs *.txt
+{% endif %}
 recursive-include docs Makefile
 {% endif %}
 
+{% if have_src_folder %}
 recursive-include src *.py
+{% endif %}
 {% for line in manifest_additional_rules %}
 %(line)s
 {% endfor %}

--- a/src/zope/meta/default/MANIFEST.in.j2
+++ b/src/zope/meta/default/MANIFEST.in.j2
@@ -1,4 +1,6 @@
+{% if have_md_files %}
 include *.md
+{% endif %}
 include *.rst
 include *.txt
 include buildout.cfg

--- a/src/zope/meta/default/tests.yml.j2
+++ b/src/zope/meta/default/tests.yml.j2
@@ -97,7 +97,7 @@ jobs:
       run: |
 {% for line in gha_additional_install %}
         %(line)s
-  {% endfor %}
+{% endfor %}
 {% endif %}
     - name: Install uv + caching
       uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
If you specify the `--template-overrides` option to have the `config-package` script look for template files in a custom location this PR lets you omit output files by simply putting an empty template into your template overrides path.

Rationale: I would like to use `zope.meta` to configure non-public repositories that do not need things like a `CONTRIBUTING.md` or a RTD configuration in `.readthedocs.yaml`.