### PR TITLE
Fix several issues in the PEP 420 switching script

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@ Change log
 
 1.2 (unreleased)
 ----------------
+- Add flag ``--no-tests`` to the scripts for switching to PEP 420
+  namespaces and for updating supported Python versions.
+
+- Add support for the ``--template-overrides`` flag to the Python version
+  update script because it calls ``config-package``.
 
 - Add ability to omit creating files by providing empty override templates.
 


### PR DESCRIPTION
This script improves the PEP 420 change script:

- actually respect the `--branch` flag
- don't execute the code checking `__init__.py` files in the loop that iterates over every line in `setup.py`
- shorten the change log message because...
  - a warning that is addressed to the package maintainer does not belong in a change log
  - the `zest.releaser` script `addchangelogentry` does not accept any formatting so you end up with a super-long line there
- add a new flag `--no-tests`, analogous to the same flag for the `config-package` script, that avoids running the tests. Most of the time those will produce a ton of irrelevant output during their first run and they take a long time to run.

In addition, improved the `update-python-support` script:

- support the `--no-tests` flag and pass that on to `config-package`
- support the `--template-overrides` flag and pass that on to `config-package`