### PR TITLE
Prevent setuptools problems in buildout template -> coverage

### DIFF
--- a/src/zope/meta/buildout-recipe/tox.ini.j2
+++ b/src/zope/meta/buildout-recipe/tox.ini.j2
@@ -17,6 +17,7 @@ setenv =
     COVERAGE_PROCESS_START={toxinidir}/pyproject.toml
 {% endif %}
 deps =
+    setuptools %(setuptools_version_spec)s
     coverage[toml]
 {% for line in testenv_deps %}
     %(line)s


### PR DESCRIPTION
It installed setuptools >= 80 which currently completely breaks with zc.buildout, so let's pin it here, too.

Used for https://github.com/zopefoundation/z3c.recipe.mkdir/pull/13