### PR TITLE
Update auditwheel call to mangled_package_name from current setuptools version.

### DIFF
--- a/src/zope/meta/c-code/manylinux-install.sh.j2
+++ b/src/zope/meta/c-code/manylinux-install.sh.j2
@@ -73,6 +73,6 @@ for PYBIN in /opt/python/*/bin; do
 done
 
 # Bundle external shared libraries into the wheels
-for whl in wheelhouse/%(package_name)s*.whl; do
+for whl in wheelhouse/%(mangled_package_name)s*.whl; do
     auditwheel repair "$whl" -w /io/wheelhouse/
 done

--- a/src/zope/meta/config_package.py
+++ b/src/zope/meta/config_package.py
@@ -465,6 +465,7 @@ class PackageConfiguration:
                 'manylinux-install.sh.j2', self.path / '.manylinux-install.sh',
                 self.config_type,
                 package_name=self.path.name,
+                mangled_package_name=self.path.name.replace('.', '_'),
                 manylinux_install_setup=manylinux_install_setup,
                 manylinux_aarch64_tests=manylinux_aarch64_tests,
                 with_future_python=self.with_future_python,


### PR DESCRIPTION
This fixes https://github.com/zopefoundation/zope.security/actions/runs/16515700220/job/46706011783?pr=119