### PR TITLE
Make windows pypy runs in c-code successful again.

### DIFF
--- a/src/zope/meta/c-code/pyproject_defaults.toml.j2
+++ b/src/zope/meta/c-code/pyproject_defaults.toml.j2
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools %(setuptools_version_spec)s",
+    "setuptools",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/src/zope/meta/c-code/tests.yml.j2
+++ b/src/zope/meta/c-code/tests.yml.j2
@@ -55,10 +55,6 @@ env:
   ZOPE_INTERFACE_STRICT_IRO: 1
 
   PIP_UPGRADE_STRATEGY: eager
-  # Don't get warnings about Python 2 support being deprecated. We
-  # know. The env var works for pip 20.
-  PIP_NO_PYTHON_VERSION_WARNING: 1
-  PIP_NO_WARN_SCRIPT_LOCATION: 1
 
   CFLAGS: -O3 -pipe
   CXXFLAGS: -O3 -pipe
@@ -161,6 +157,7 @@ jobs:
 {% endif %}
         run: |
           # Install to collect dependencies into the (pip) cache.
+          pip install -U pip "setuptools %(setuptools_version_spec)s"
           pip install .[test]
 
       - name: Check %(package_name)s build


### PR DESCRIPTION
Used for https://github.com/zopefoundation/zope.i18nmessageid/pull/65

Reason of the changes:

* Some c-code packages could not be built successfully on pypy-windows because `setuptools == 78.1.1` could not be found. The list of known `setuptools` versions ends at 76.0.0 Source: https://github.com/zopefoundation/zope.i18nmessageid/actions/runs/17316990877/job/49161644379
* I tried to install `setuptools==78.1.1` beforehand, and found out that it is already there but the `pip install .[test]` command complains that it cannot see it. Source: https://github.com/zopefoundation/zope.i18nmessageid/actions/runs/17370121781/job/49303957516
* Even putting the installation of `setuptools` and `.[test]` into the same pip call did not help. Source: https://github.com/zopefoundation/zope.i18nmessageid/actions/runs/17370397026/job/49304788788
* What was helpful was to use `setuptools < 78.1.2` in `pyproject.toml`. source: https://github.com/zopefoundation/zope.i18nmessageid/pull/65/commits/c10acb20c5c87cce052bdee5f9022671194f0e92
* So I decided to install the required `setuptools` version beforehand and not to require a specific version in `pyproject.toml`