### PR TITLE
Fix handling of ``tool`` section during ``pyproject.toml`` generation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Change log
 2.0 (unreleased)
 ----------------
 
+- Fix handling of ``tool`` section during ``pyproject.toml`` generation.
+
 - Add support for Python 3.14.
 
 - Drop support for Python 3.9.

--- a/src/zope/meta/config_package.py
+++ b/src/zope/meta/config_package.py
@@ -646,6 +646,7 @@ class PackageConfiguration:
 
         # Capture some pre-transformation data
         old_requires = toml_doc.get('build-system', {}).get('requires', [])
+        old_tools = toml_doc.get('tool', {})
 
         # Apply template-dependent defaults
         toml_defaults = self.render_with_meta(
@@ -668,6 +669,12 @@ class PackageConfiguration:
                 x for x in old_requires if x.startswith('wheel')]
             [old_requires.remove(x) for x in wheel_requirement]
             toml_doc['build-system']['requires'].extend(old_requires)
+
+        # Fix up tool sections because the call to ``update`` above will
+        # replace the entire ``tool`` mapping...
+        for k, v in old_tools.items():
+            if k != 'coverage':  # `coverage` settings are handled by template
+                toml_doc['tool'][k] = v
 
         # Update coverage-related data
         coverage = toml_doc['tool']['coverage']


### PR DESCRIPTION
Our templates for ``pyproject.toml`` contain several ``tool.coverage`` sections. Unfortunately, merging those defaults into the contents of the package's own ``pyproject.toml`` will simply replace everything under the ``tool`` key with the ``tool`` contents from our template.

This change captures the ``tool`` sections from the package's own ``pyproject.toml`` and re-adds all keys under ``tool`` with the exception of ``coverage``, which is taken from our template.

Use case where I saw the issue: When moving namespace package discovery settings from ``setup.py`` to ``pyproject.toml`` a key ``[tool.setuptools.packages.find]`` is needed, which was simply gone after running ``config-package``.