### PR TITLE
Add option to show file changes after a failed ``tox`` ``lint`` run or not

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Change log
 2.2 (unreleased)
 ----------------
 
+- Add option to show file changes after a failed ``tox`` ``lint`` run or not.
+  For backwards compatibility this is still ``True`` if not set.
+
 - Add script to move package metadata from ``setup.py`` to ``pyproject.toml``.
 
 - Move commonly used script argument processing into shared library file.

--- a/docs/narr.rst
+++ b/docs/narr.rst
@@ -273,6 +273,7 @@ updated. Example:
     docs-deps = [
         "urllib3 < 2",
         ]
+    lint-diff-on-failure = true
 
     [flake8]
     additional-config = [
@@ -494,6 +495,15 @@ docs-deps
   ``[testenv:docs]`` in ``tox.ini``. This option has to be a list of strings
   and is empty by default. Caution: The values set for this option override
   the ones set in ``[testenv]``.
+
+lint-diff-on-failure
+  In the past, the ``lint`` step always called ``pre-commit`` with the option
+  ``--show-diff-on-failure``, which meant any linting failures would
+  automatically dump a diff with any outstanding changes in the entire package,
+  even if they are unrelated to linting, to the console. This is not helpful
+  unless there are very few changes and the diff is manageable. Setting this
+  option to ``false`` prevents showing the diff. If not set, the default is
+  ``true`` for backwards compatibility.
 
 
 Flake8 options

--- a/src/zope/meta/config_package.py
+++ b/src/zope/meta/config_package.py
@@ -473,6 +473,7 @@ class PackageConfiguration:
         coverage_additional = self.tox_option('coverage-additional')
         testenv_deps = self.tox_option('testenv-deps')
         coverage_setenv = self.tox_option('coverage-setenv')
+        lint_diff_on_failure = self.tox_option('lint-diff-on-failure', True)
         flake8_additional_sources = self.meta_cfg['flake8'].get(
             'additional-sources', '')
         if flake8_additional_sources:
@@ -499,6 +500,7 @@ class PackageConfiguration:
             coverage_fail_under=self.coverage_fail_under,
             flake8_additional_sources=flake8_additional_sources,
             isort_additional_sources=isort_additional_sources,
+            lint_diff_on_failure=lint_diff_on_failure,
             testenv_additional=testenv_additional,
             testenv_additional_extras=testenv_additional_extras,
             testenv_commands=testenv_commands,

--- a/src/zope/meta/default/tox-lint.j2
+++ b/src/zope/meta/default/tox-lint.j2
@@ -9,4 +9,5 @@ deps =
     pre-commit
 commands_pre =
 commands =
-    pre-commit run --all-files --show-diff-on-failure
+    pre-commit run --all-files{% if lint_diff_on_failure %} --show-diff-on-failure{% endif %}
+


### PR DESCRIPTION
One of the default behaviors that always bothered me is the fact that a failed ``lint`` run would always dump a diff with all uncommitted changes to the console. This may be fine if you have a habit of committing very small changes, but when you have made a lot of changes (most of which will be totally unrelated to any linting failure) and all of a sudden the screen scrolls away with a huge diff then that's seriously unhelpful bordering on annoying. I always have to scroll back to see the actual linting failure messages.

This PR adds an option to toggle that diff on or off. The default if it's unset is still on, so there is no behavior change for existing packages unless you explicitly want it.