### PR TITLE
When moving metadata to ``pyproject.toml``, ignore ``setup py test`` fossils

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Change log
 2.2 (unreleased)
 ----------------
 
+- When moving metadata to ``pyproject.toml``, ignore ``setup py test`` fossils.
+  (`#260 <https://github.com/zopefoundation/meta/issues/260>`_)
+
 - Allow overriding configuration values in ``zope.meta.shared.packages``
   by using the ``--overrides`` option and placing a TOML file named
   ``overrides.toml`` into the overrides folder.

--- a/src/zope/meta/setup_to_pyproject.py
+++ b/src/zope/meta/setup_to_pyproject.py
@@ -37,7 +37,7 @@ PROJECT_SIMPLE_KEYS = (
 )
 IGNORE_KEYS = (
     'zip_safe', 'long_description_content_type', 'package_dir',
-    'packages', 'include_package_data',
+    'packages', 'include_package_data', 'test_suite', 'tests_require',
 )
 UNCONVERTIBLE_KEYS = (
     'cmdclass', 'ext_modules', 'headers', 'cffi_modules',


### PR DESCRIPTION
See https://github.com/zopefoundation/meta/issues/260

This does not solve the issue immediately, but at least when an affected package is converted to `pyproject.toml` metadata.