### PR TITLE
Print out a warning if a ``setuptools`` install time dependency is found

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Change log
 2.2 (unreleased)
 ----------------
 
+- Print out a warning if a ``setuptools`` install time dependency is found
+  when runing the the ``config-package`` and ``setup-to-pyproject`` scripts.
+
 - Change ``c-code`` GitHub Actions publishing step to use
   PyPI's "Trusted Publishing".
   (`#198 <https://github.com/zopefoundation/meta/issues/198>`_)

--- a/src/zope/meta/config_package.py
+++ b/src/zope/meta/config_package.py
@@ -605,6 +605,14 @@ class PackageConfiguration:
         old_requires = toml_doc.get('build-system', {}).get('requires', [])
         old_tools = toml_doc.get('tool', {})
 
+        # Do some sanity checking
+        project_settings = toml_doc.get('project', {})
+        for install_dependency in project_settings.get('dependencies', []):
+            if install_dependency.startswith('setuptools'):
+                print('XXX Found "setuptools" as install time dependency.')
+                print('XXX Please check if it is really needed!')
+                break
+
         # Apply template-dependent defaults
         toml_defaults = self.render_with_meta(
             'pyproject_defaults.toml.j2',

--- a/src/zope/meta/setup_to_pyproject.py
+++ b/src/zope/meta/setup_to_pyproject.py
@@ -239,6 +239,11 @@ def setup_args_to_toml_dict(setup_py_path, setup_kwargs):
 
     install_reqs = setup_kwargs.pop('install_requires', [])
     if install_reqs:
+        for dependency in install_reqs:
+            if dependency.startswith('setuptools'):
+                print('XXX Found "setuptools" as install time dependency.')
+                print('XXX Please check if it is really needed!')
+                break
         p_data['dependencies'] = install_reqs
 
     keywords = setup_kwargs.pop('keywords', '')


### PR DESCRIPTION
See #345 

This does not simply delete the dependency, but prints out a warning. The dependency may be legitimate.