### PR TITLE
Remove special treatment for macOS test runners on GitHub

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Change log
 2.2 (unreleased)
 ----------------
 
+- Remove special treatment for macOS test runners on GitHub
+
 - Print out a warning if a ``setuptools`` install time dependency is found
   when runing the the ``config-package`` and ``setup-to-pyproject`` scripts.
 

--- a/src/zope/meta/default/tests.yml.j2
+++ b/src/zope/meta/default/tests.yml.j2
@@ -110,7 +110,6 @@ jobs:
         python-version: ${{ matrix.config[0] }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Test
-      if: ${{ !startsWith(runner.os, 'Mac') }}
 {% if gha_test_environment %}
       env:
       {% for line in gha_test_environment %}
@@ -125,15 +124,6 @@ jobs:
 {% else %}
       run: uvx --with tox-uv tox -e ${{ matrix.config[1] }}
 {% endif %}
-    - name: Test (macOS)
-      if: ${{ startsWith(runner.os, 'Mac') }}
-{% if gha_test_environment %}
-      env:
-      {% for line in gha_test_environment %}
-        %(line)s
-      {% endfor %}
-{% endif %}
-      run: uvx --with tox-uv tox -e ${{ matrix.config[1] }}-universal2
     - name: Coverage
       if: matrix.config[1] == 'coverage'
       run: |


### PR DESCRIPTION
Fixes test failures at https://github.com/zopefoundation/Products.ZCatalog/actions/runs/20894894972/job/60031842321, tested on both Products.ZCatalog and Zope, which are the only places that actually used the special treatment.