### PR TITLE
Add Windows ARM64 support to c-code CI template

### DIFF
--- a/src/zope/meta/c-code/tests-download-linux.j2
+++ b/src/zope/meta/c-code/tests-download-linux.j2
@@ -1,0 +1,5 @@
+      - name: Download %(package_name)s wheel
+        uses: actions/download-artifact@v8
+        with:
+          name: %(package_name)s-${{ runner.os }}-${{ matrix.python-version }}.whl
+          path: dist/

--- a/src/zope/meta/c-code/tests-download.j2
+++ b/src/zope/meta/c-code/tests-download.j2
@@ -1,6 +1,13 @@
-
-      - name: Download %(package_name)s wheel
+      - name: Download %(package_name)s wheel (Linux/macOS)
+        if: "!startsWith(runner.os, 'Windows')"
         uses: actions/download-artifact@v8
         with:
           name: %(package_name)s-${{ runner.os }}-${{ matrix.python-version }}.whl
+          path: dist/
+
+      - name: Download %(package_name)s wheel (Windows)
+        if: startsWith(runner.os, 'Windows')
+        uses: actions/download-artifact@v8
+        with:
+          name: %(package_name)s-${{ runner.os }}-${{ matrix.python-version }}-${{ runner.arch }}.whl
           path: dist/

--- a/src/zope/meta/c-code/tests-strategy.j2
+++ b/src/zope/meta/c-code/tests-strategy.j2
@@ -12,16 +12,22 @@
           - "%(future_python_version)s"
 {% endif %}
 {% if with_windows %}
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
 {% else %}
         os: [ubuntu-latest, macos-latest]
 {% endif %}
-{% if with_pypy or gha_additional_exclude %}
+{% if with_pypy or gha_additional_exclude or with_windows %}
         exclude:
 {% endif %}
 {% if with_pypy %}
           - os: macos-latest
             python-version: "pypy-%(pypy_version)s"
+          - os: windows-11-arm
+            python-version: "pypy-%(pypy_version)s"
+{% endif %}
+{% if with_windows %}
+          - os: windows-11-arm
+            python-version: "3.10"
 {% endif %}
 {% for line in gha_additional_exclude %}
           %(line)s

--- a/src/zope/meta/c-code/tests.yml.j2
+++ b/src/zope/meta/c-code/tests.yml.j2
@@ -160,7 +160,7 @@ jobs:
         run: |
           ls -l dist
           twine check dist/*
-{% for kind in ('macOS x86_64', 'macOS arm64', 'all other platforms') %}
+{% for kind in ('macOS x86_64', 'macOS arm64') %}
       - name: Upload %(package_name)s wheel (%(kind)s)
         if: >
   {% if kind == 'macOS x86_64' %}
@@ -168,8 +168,6 @@ jobs:
   {% elif kind == 'macOS arm64' or kind == 'macOS universal2' %}
           startsWith(runner.os, 'Mac')
           && !startsWith(matrix.python-version, 'pypy')
-  {% else %}
-          !startsWith(runner.os, 'Mac')
   {% endif %}
         uses: actions/upload-artifact@v7
         with:
@@ -192,10 +190,21 @@ jobs:
           path: dist/*arm64.whl
   {% elif kind == 'macOS universal2' %}
           path: dist/*universal2.whl
-  {% else %}
-          path: dist/*whl
   {% endif %}
 {% endfor %}
+      - name: Upload %(package_name)s wheel (Windows)
+        if: startsWith(runner.os, 'Windows')
+        uses: actions/upload-artifact@v7
+        with:
+          name: %(package_name)s-${{ runner.os }}-${{ matrix.python-version }}-${{ runner.arch }}.whl
+          path: dist/*whl
+
+      - name: Upload %(package_name)s wheel (Linux)
+        if: startsWith(runner.os, 'Linux')
+        uses: actions/upload-artifact@v7
+        with:
+          name: %(package_name)s-${{ runner.os }}-${{ matrix.python-version }}.whl
+          path: dist/*whl
 
   test:
     needs: build-package
@@ -295,7 +304,7 @@ jobs:
 
     steps:
 {% include 'tests-cache.j2' %}
-{% include 'tests-download.j2' %}
+{% include 'tests-download-linux.j2' %}
       - name: Install %(package_name)s
         run: |
           pip install -U wheel
@@ -321,7 +330,7 @@ jobs:
 
     steps:
 {% include 'tests-cache.j2' %}
-{% include 'tests-download.j2' %}
+{% include 'tests-download-linux.j2' %}
       - name: Install %(package_name)s
         run: |
           pip install -U wheel


### PR DESCRIPTION
This PR updates the c-code CI template to support Windows ARM64 (windows-11-arm) runners.

### Changes

#### tests-strategy.j2
- Added `windows-11-arm` to the OS matrix when `with_windows` is enabled
- Added exclude for `pypy` on `windows-11-arm` (not supported)
- Added exclude for oldest Python version on `windows-11-arm` (not supported)

#### tests-download.j2
- Split into two separate download steps for Linux/macOS and Windows
- Windows step uses `${{ runner.arch }}` in artifact name to distinguish between `windows-latest` (X64) and `windows-11-arm` (ARM64)

#### tests-download-linux.j2 (new file)
- Single download step for jobs that only run on Linux (docs, release-check)

#### tests.yml.j2
- Updated `docs` and `release-check` jobs to use `tests-download-linux.j2`
- Split Windows and Linux upload steps separately with `runner.arch` in Windows artifact name

## Related
- Closes zopefoundation/zope.interface#366

- [x] I signed and returned the [Zope Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the zopefoundation GitHub organization.