### PR TITLE
Reinstate checking Python versions in tests.yml

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Change log
 2.2 (unreleased)
 ----------------
 
+- Reinstate checking ``tests.yml`` in ``check-python-versions``
+  after the ``check-python-versions`` package was fixed.
+  (See `#396 <https://github.com/zopefoundation/meta/issues/396>`_)
+
 - Pin "teyit" in `precommitconfig.yaml.j2` to use Python 3.13 
   (must be available locally, like in path or via pyenv/uv). 
   teyit does not support Python 3.14 yet.

--- a/src/zope/meta/default/tox-release-check.j2
+++ b/src/zope/meta/default/tox-release-check.j2
@@ -9,15 +9,11 @@ deps =
     twine
     build
     check-manifest
-    check-python-versions >= 0.20.0
+    check-python-versions >= 0.24.2
     wheel
 commands_pre =
 commands =
     check-manifest
-{% if with_free_threaded_python %}
-    check-python-versions --only pyproject.toml,setup.py,tox.ini
-{% else %}
     check-python-versions --only pyproject.toml,setup.py,tox.ini,.github/workflows/tests.yml
-{% endif %}
     python -m build --sdist --no-isolation
     twine check dist/*


### PR DESCRIPTION
This PR essentially reverses the changes from #396, which are not needed anymore because the `check-python-versions` package was fixed.

Tested in https://github.com/zopefoundation/zope.interface/actions/runs/24452665495/job/71446149322 - I have not created a PR there because I believe the zope.meta changes for Windows on arm64 that are applied there as well are broken.