### PR TITLE
Fix pip cache key to include architecture for Windows ARM64 support

### DIFF
--- a/src/zope/meta/c-code/tests-cache.j2
+++ b/src/zope/meta/c-code/tests-cache.j2
@@ -32,7 +32,7 @@
           path: ${{ steps.pip-cache-default.outputs.dir }}
           key: %(cache_key)s
           restore-keys: |
-            ${{ runner.os }}-pip-
+            ${{ runner.os }}-${{ runner.arch }}-pip-
 
       - name: pip cache (Windows)
         uses: actions/cache@v5
@@ -41,4 +41,4 @@
           path: ${{ steps.pip-cache-windows.outputs.dir }}
           key: %(cache_key)s
           restore-keys: |
-            ${{ runner.os }}-pip-
+            ${{ runner.os }}-${{ runner.arch }}-pip-

--- a/src/zope/meta/c-code/tests.yml.j2
+++ b/src/zope/meta/c-code/tests.yml.j2
@@ -1,4 +1,4 @@
-{% set cache_key = "${{ runner.os }}-pip-${{ matrix.python-version }}" %}
+{% set cache_key = "${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}" %}
 ###
 # Initially copied from
 # https://github.com/actions/starter-workflows/blob/main/ci/python-package.yml


### PR DESCRIPTION
This PR updates the cache key logic in the c-code GitHub Actions template to include the runner architecture.

Previously, cache keys were based only on the OS and Python version:

`${{ runner.os }}-pip-${{ matrix.python-version }}`

With the addition of Windows ARM64 jobs, this caused cache collisions between x64 and ARM64 builds for the same Python version, leading to intermittent failures and incorrect cache restores.

Changes

- Updated cache key to include runner architecture: `${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}`

- Updated restore keys to include architecture as well

This prevents cache collisions between x64 and ARM64 jobs and avoids incorrect cache reuse, stabilizing CI runs.

- [x] I signed and returned the [Zope Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the zopefoundation GitHub organization.


Closes #409
