### PR TITLE
Create and upload sdist artifacts

### DIFF
--- a/src/zope/meta/c-code/tests.yml.j2
+++ b/src/zope/meta/c-code/tests.yml.j2
@@ -138,6 +138,13 @@ jobs:
           python setup.py bdist_wheel
 {% endfor %}
 
+      - name: Create %(package_name)s sdist
+        if: >
+          startsWith(runner.os, 'Linux')
+          && matrix.python-version == '%(newest_python_version)s'
+        run: |
+          python setup.py sdist
+
 {% if with_future_python %}
       - name: Install %(package_name)s and dependencies (%(future_python_version)s)
         if: matrix.python-version == '%(future_python_version)s'
@@ -205,6 +212,15 @@ jobs:
         with:
           name: %(package_name)s-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/*whl
+
+      - name: Upload %(package_name)s sdist
+        if: >
+          startsWith(runner.os, 'Linux')
+          && matrix.python-version == '%(newest_python_version)s'
+        uses: actions/upload-artifact@v7
+        with:
+          name: %(package_name)s-${{ github.ref_name }}.tar.gz
+          path: dist/*gz
 
   test:
     needs: build-package


### PR DESCRIPTION
Fixes #412 

This change adds creation and upload of artifacts for an sdist o the c-code GHA tests.yml template. This sdist is then correctly picked up and published by the PyPI upload step when a tag is set.

Tested with zope.interface:
- test run https://github.com/zopefoundation/zope.interface/actions/runs/24929217589
- creation/upload of an sdist for the Linux runner using the latest supported Python only: https://github.com/zopefoundation/zope.interface/actions/runs/24929217589/job/73004172269
- Publishing wheels and the sdist: https://github.com/zopefoundation/zope.interface/actions/runs/24929217589/job/73004318881
- List of packages for the test release zope.interface 8.4.1a1: https://pypi.org/project/zope.interface/8.4.1a1/#files

If you click on "Details" next to the source distribution you can verify that it was published using the trusted publishing mechanism.