### PR TITLE
Move zest.releaser config from setup.cfg to pyproject.toml

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Change log
 2.2 (unreleased)
 ----------------
 
+- Move ``zest.releaser`` configuration from ``setup.cfg`` to
+  ``pyproject.toml`` where it is the ``[tool.zest-releaser]`` section.
+
 - Update the ``setuptools`` version pin from ``<81`` to ``<82``.
   (`#414 <https://github.com/zopefoundation/meta/issues/414>`_)
 

--- a/docs/narr.rst
+++ b/docs/narr.rst
@@ -672,7 +672,8 @@ The corresponding section is named: ``[zest-releaser]`` (with an ``-`` instead
 of the ``.``).
 
 options
-  (Additional) options used to configure ``zest.releaser``. This option has to
+  (Additional) options used to configure ``zest.releaser`` via the
+  ``[tool.zest-releaser]`` section in ``pyproject.toml``. This option has to
   be a list of strings and defaults to an empty list.
 
 

--- a/src/zope/meta/config_package.py
+++ b/src/zope/meta/config_package.py
@@ -346,11 +346,6 @@ class PackageConfiguration:
         isort_additional_config = self.cfg_option(
             'isort', 'additional-config')
 
-        zest_releaser_options = self.meta_cfg['zest-releaser'].get(
-            'options', [])
-        if self.config_type == 'c-code':
-            zest_releaser_options.append('create-wheel = no')
-
         self.copy_with_meta(
             'setup.cfg.j2',
             self.path / 'setup.cfg',
@@ -365,7 +360,6 @@ class PackageConfiguration:
             isort_additional_config=isort_additional_config,
             with_docs=self.with_docs,
             with_sphinx_doctests=self.with_sphinx_doctests,
-            zest_releaser_options=zest_releaser_options,
         )
 
     def setup_py(self):
@@ -669,6 +663,18 @@ class PackageConfiguration:
         omit = self.meta_cfg['coverage-run'].get('omit', [])
         if omit:
             coverage['run']['omit'] = omit
+
+        # Update zest.releaser configuration
+        zest_releaser_options = self.meta_cfg['zest-releaser'].get(
+            'options', [])
+        zest_releaser_data = parse_additional_config(zest_releaser_options)
+        if self.config_type == 'c-code':
+            zest_releaser_data['create-wheel'] = False
+            zest_releaser_data['upload-pypi'] = False
+        if zest_releaser_data:
+            toml_doc['tool']['zest-releaser'] = zest_releaser_data
+        elif 'zest-releaser' in toml_doc.get('tool', {}):
+            del toml_doc['tool']['zest-releaser']
 
         # Remove empty sections
         for key, value in toml_doc.items():

--- a/src/zope/meta/default/setup.cfg.j2
+++ b/src/zope/meta/default/setup.cfg.j2
@@ -1,11 +1,3 @@
-{% if zest_releaser_options %}
-
-[zest.releaser]
-{% for line in zest_releaser_options %}
-%(line)s
-{% endfor %}
-{% endif %}
-
 [flake8]
 doctests = 1
 {% if config_type == 'buildout-recipe' %}


### PR DESCRIPTION
The `zest.releaser` configuration options do not work when set in `setup.cfg`. This PR moves them to the `[tool.zest-releaser]` section in `pyproject.toml` instead.

### Changes
- Removed zest.releaser section from `setup.cfg.j2` template
- Added zest.releaser config writing to `pyproject_toml()` in `config_package.py`
- For `c-code` packages, `create-wheel` and `upload-pypi` are set as proper TOML booleans (`false`)
- Updated documentation in `docs/narr.rst`