### PR TITLE
Drop cache action `restore-keys` to prevent bad cache hits

### DIFF
--- a/src/zope/meta/c-code/tests-cache.j2
+++ b/src/zope/meta/c-code/tests-cache.j2
@@ -31,8 +31,6 @@
         with:
           path: ${{ steps.pip-cache-default.outputs.dir }}
           key: %(cache_key)s
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-pip-
 
       - name: pip cache (Windows)
         uses: actions/cache@v5
@@ -40,5 +38,4 @@
         with:
           path: ${{ steps.pip-cache-windows.outputs.dir }}
           key: %(cache_key)s
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-pip-
+


### PR DESCRIPTION
As observed in several places like https://github.com/zopefoundation/zope.security/pull/128 the `restore-keys` setting can lead to wrong caches used.

The line break at the end of the file is on purpose to reduce visual clutter in the resulting tests configuration.