### PR TITLE
Update branch protection rules in ``set_branch_protection_rules``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Change log
 2.2 (unreleased)
 ----------------
 
+- Update the branch protection rules for ``set_branch_protection_rules``
+
 - Add an option to enable releases to be built and published automatically
   using PyPI Trusted Publishing for non-``c-code`` projects.
 

--- a/src/zope/meta/set_branch_protection_rules.py
+++ b/src/zope/meta/set_branch_protection_rules.py
@@ -34,7 +34,7 @@ def _call_gh(
         'gh', 'api',
         '--method', method,
         '-H', 'Accept: application/vnd.github+json',
-        '-H', 'X-GitHub-Api-Version: 2022-11-28',
+        '-H', 'X-GitHub-Api-Version: 2026-03-10',
         f'/repos/{ORG}/{repo}/branches/{DEFAULT_BRANCH}/{path}',
         *args, capture_output=capture_output,
         allowed_return_codes=allowed_return_codes)
@@ -45,7 +45,7 @@ def set_branch_protection(
     result = _call_gh(
         'GET', 'protection/required_pull_request_reviews', repo,
         allowed_return_codes=(0, 1))
-    required_pull_request_reviews = None
+    required_pr_reviews = None
     if result.returncode == 1:
         if json.loads(result.stdout)['message'] != "Branch not protected":
             # If there is no branch protection we create it later on using the
@@ -53,11 +53,26 @@ def set_branch_protection(
             print(result.stdout)
             abort(result.returncode)
     else:
-        required_approving_review_count = json.loads(
-            result.stdout)['required_approving_review_count']
-        required_pull_request_reviews = {
-            'required_approving_review_count': required_approving_review_count
+        pr_rules = json.loads(result.stdout)
+        required_approvals = pr_rules['required_approving_review_count']
+        required_pr_reviews = {
+            'required_approving_review_count': required_approvals,
+            'dismiss_stale_reviews': True,
         }
+
+        # Dig through the bypass_pull_request_allowances mapping so all
+        # elements are preserved if we need to change one
+        bp_rules = pr_rules.get('bypass_pull_request_allowances', {})
+        bp_apps = [x['slug'] for x in bp_rules.get('apps', [])]
+        bp_teams = [x['slug'] for x in bp_rules.get('teams', [])]
+        bp_users = [x['login'] for x in bp_rules.get('users', [])]
+        if 'release-managers' not in bp_teams:
+            bp_teams.append('release-managers')
+            required_pr_reviews['bypass_pull_request_allowances'] = {
+                'apps': bp_apps,
+                'teams': bp_teams,
+                'users': bp_users,
+            }
 
     if meta_path is None:
         response = requests.get(
@@ -145,13 +160,14 @@ def set_branch_protection(
         'allow_deletions': False,
         'allow_force_pushes': False,
         'allow_fork_syncing': True,
+        'dismiss_stale_reviews': True,
         'lock_branch': False,
         'enforce_admins': None,
         'restrictions': None,
         'required_conversation_resolution': True,
         'required_linear_history': False,
-        'required_pull_request_reviews': required_pull_request_reviews,
-        'required_status_checks': {'contexts': required, 'strict': False}
+        'required_pull_request_reviews': required_pr_reviews,
+        'required_status_checks': {'contexts': required, 'strict': True}
     }
     fd, filename = tempfile.mkstemp('config.json', 'meta', text=True)
     try:

--- a/src/zope/meta/set_branch_protection_rules.py
+++ b/src/zope/meta/set_branch_protection_rules.py
@@ -160,7 +160,6 @@ def set_branch_protection(
         'allow_deletions': False,
         'allow_force_pushes': False,
         'allow_fork_syncing': True,
-        'dismiss_stale_reviews': True,
         'lock_branch': False,
         'enforce_admins': None,
         'restrictions': None,


### PR DESCRIPTION
This PR tweaks the branch protection rules codified in the helper script ``set_branch_protection_rules``. The rules we have are decent already, maybe the fact that they have been enforced through the script for a long time now has helped us duck the attacks we see on the Collective repositories.

Each of these changes is meant as a starting point for discussion, none of it is set in stone:

- Enforce "Dismiss stale pull request approvals when new commits are pushed": This results in a little more work in some cases where a PR is changed after reviewer approval. Most of the time reviewers will not approve when they want to see changes, so this is an edge case. But it prevents unreviewed commits on the protected branch.
- Add the organization group "Release Managers" to the setting "Allow specified actors to bypass required pull requests ". I am not sure about this one, it seems it's no longer necessary after adding the organization-wide "All-repository admin" role to the group to make the standard development workflow work again for non-admins.
- Enforce "Require branches to be up to date before merging", which is not really security-related but seems a good idea, anyway.

I also update the GitHub API version to be used from the old `2022-11-28` to the most recent `2026-03-10`.