### PR TITLE
Update c-code test template: pre-install cffi and switch coveralls action

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,10 @@ Change log
 2.2 (unreleased)
 ----------------
 
-- Pre-install ``cffi`` and ``pycparser`` for future Python builds and switch
-  to ``coverallsapp/github-action@v2`` in the ``c-code`` test workflow template.
+- Pre-install ``cffi`` and ``pycparser`` for future Python builds.
+
+- Switch to ``coverallsapp/github-action@v2`` in the ``c-code`` test workflow
+  template.
 
 - Add an option to enable releases to be built and published automatically
   using PyPI Trusted Publishing for non-``c-code`` projects.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Change log
 2.2 (unreleased)
 ----------------
 
+- Pre-install ``cffi`` and ``pycparser`` for future Python builds and switch
+  to ``coverallsapp/github-action@v2`` in the ``c-code`` test workflow template.
+
 - Add an option to enable releases to be built and published automatically
   using PyPI Trusted Publishing for non-``c-code`` projects.
 

--- a/src/zope/meta/c-code/tests.yml.j2
+++ b/src/zope/meta/c-code/tests.yml.j2
@@ -93,7 +93,7 @@ jobs:
         if: matrix.python-version == '%(future_python_version)s'
         run: |
           pip install -U pip
-          pip install -U "setuptools %(setuptools_version_spec)s" wheel twine
+          pip install -U "setuptools %(setuptools_version_spec)s" wheel twine cffi pycparser
 {% endif %}
       - name: Install Build Dependencies
 {% if with_future_python %}
@@ -296,7 +296,7 @@ jobs:
       - name: Submit to Coveralls
         # This is a container action, which only runs on Linux.
         if: ${{ startsWith(runner.os, 'Linux') }}
-        uses: AndreMiras/coveralls-python-action@develop
+        uses: coverallsapp/github-action@v2
         with:
           parallel: true
 
@@ -305,7 +305,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Coveralls Finished
-      uses: AndreMiras/coveralls-python-action@develop
+      uses: coverallsapp/github-action@v2
       with:
         parallel-finished: true
 {% if with_docs %}


### PR DESCRIPTION
On ARM64 macOS runners, the x86_64 cross-compilation step causes `setup_requires`/`fetch_build_eggs` to build cffi from source with x86_64 flags (no pre-built wheel exists yet for future Python). Python (arm64) then cannot load the x86_64 `_cffi_backend.so`. Pre-installing `cffi` and `pycparser` via pip ensures they are available natively.

Also switches the coveralls action from the unmaintained `AndreMiras/coveralls-python-action@develop` to `coverallsapp/github-action@v2`. Somehow nowadays only actions from the Marketplace can be used.

Based on https://github.com/zopefoundation/persistent/pull/233.