### PR TITLE
Expand free-threaded Python support to all platforms in c-code templates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Change log
 2.2 (unreleased)
 ----------------
 
+- Expand free-threaded Python CI testing from Linux-only to all platforms
+  (macOS, Windows) in ``c-code`` templates. Add future Python free-threaded
+  variant (e.g. ``3.15t``) support to the test matrix, manylinux build
+  scripts, and tox configuration.
+
 - Pre-install ``cffi`` and ``pycparser`` for future Python builds.
 
 - Switch to ``coverallsapp/github-action@v2`` in the ``c-code`` test workflow

--- a/src/zope/meta/c-code/manylinux-install.sh.j2
+++ b/src/zope/meta/c-code/manylinux-install.sh.j2
@@ -30,9 +30,15 @@ yum -y install libffi-devel
 tox_env_map() {
     case $1 in
 {% for py_version in supported_python_versions %}
+{% if with_free_threaded_python and loop.last %}
+        *"cp%(py_version)st"*) echo 'py%(py_version)st';;
+{% endif %}
         *"cp%(py_version)s"*) echo 'py%(py_version)s';;
 {% endfor %}
 {% if with_future_python %}
+{% if with_free_threaded_python %}
+        *"cp%(future_python_shortversion)st"*) echo 'py%(future_python_shortversion)st';;
+{% endif %}
         *"cp%(future_python_shortversion)s"*) echo 'py%(future_python_shortversion)s';;
 {% endif %}
         *) echo 'py';;
@@ -46,13 +52,19 @@ for PYBIN in /opt/python/*/bin; do
        [[ "${PYBIN}" == *"cp%(py_version)s/"* ]] {% if py_version != stop_at %}|| \
 {% endif %}
 {% endfor %}
-{% if with_future_python %}
+{% if with_free_threaded_python and with_future_python %}
+       [[ "${PYBIN}" == *"cp%(newest_python_shortversion)st/"* ]] || \
+       [[ "${PYBIN}" == *"cp%(future_python_shortversion)s/"* ]] || \
+       [[ "${PYBIN}" == *"cp%(future_python_shortversion)st/"* ]] ; then
+{% elif with_free_threaded_python %}
+       [[ "${PYBIN}" == *"cp%(newest_python_shortversion)st/"* ]] ; then
+{% elif with_future_python %}
        [[ "${PYBIN}" == *"cp%(future_python_shortversion)s/"* ]] ; then
 {% else %}
 ; then
 {% endif %}
 {% if with_future_python %}
-        if [[ "${PYBIN}" == *"cp%(future_python_shortversion)s/"* ]] ; then
+        if [[ "${PYBIN}" == *"cp%(future_python_shortversion)s/"* ]] {% if with_free_threaded_python %}|| [[ "${PYBIN}" == *"cp%(future_python_shortversion)st/"* ]] {% endif %}; then
             "${PYBIN}/pip" install --pre -e /io/
             "${PYBIN}/pip" wheel /io/ --pre -w wheelhouse/
         else

--- a/src/zope/meta/c-code/tests-strategy.j2
+++ b/src/zope/meta/c-code/tests-strategy.j2
@@ -36,4 +36,20 @@
         include:
           - python-version: "%(newest_python_version)st"
             os: ubuntu-latest
+          - python-version: "%(newest_python_version)st"
+            os: macos-latest
+{% if with_windows %}
+          - python-version: "%(newest_python_version)st"
+            os: windows-latest
+{% endif %}
+{% if with_future_python %}
+          - python-version: "%(future_python_version)st"
+            os: ubuntu-latest
+          - python-version: "%(future_python_version)st"
+            os: macos-latest
+{% if with_windows %}
+          - python-version: "%(future_python_version)st"
+            os: windows-latest
+{% endif %}
+{% endif %}
 {% endif %}

--- a/src/zope/meta/c-code/tests.yml.j2
+++ b/src/zope/meta/c-code/tests.yml.j2
@@ -90,14 +90,14 @@ jobs:
 
 {% if with_future_python %}
       - name: Install Build Dependencies (%(future_python_version)s)
-        if: matrix.python-version == '%(future_python_version)s'
+        if: startsWith(matrix.python-version, '%(future_python_version)s')
         run: |
           pip install -U pip
           pip install -U "setuptools %(setuptools_version_spec)s" wheel twine cffi pycparser
 {% endif %}
       - name: Install Build Dependencies
 {% if with_future_python %}
-        if: matrix.python-version != '%(future_python_version)s'
+        if: ${{ !startsWith(matrix.python-version, '%(future_python_version)s') }}
 {% endif %}
         run: |
           pip install -U pip
@@ -147,7 +147,7 @@ jobs:
 
 {% if with_future_python %}
       - name: Install %(package_name)s and dependencies (%(future_python_version)s)
-        if: matrix.python-version == '%(future_python_version)s'
+        if: startsWith(matrix.python-version, '%(future_python_version)s')
         run: |
           # Install to collect dependencies into the (pip) cache.
           # Use "--pre" here because dependencies with support for this future
@@ -156,7 +156,7 @@ jobs:
 {% endif %}
       - name: Install %(package_name)s and dependencies
 {% if with_future_python %}
-        if: matrix.python-version != '%(future_python_version)s'
+        if: ${{ !startsWith(matrix.python-version, '%(future_python_version)s') }}
 {% endif %}
         run: |
           # Install to collect dependencies into the (pip) cache.
@@ -166,7 +166,14 @@ jobs:
       - name: Check %(package_name)s build
         run: |
           ls -l dist
+{% if with_free_threaded_python %}
+      - name: Check %(package_name)s build (twine)
+        if: ${{ !endsWith(matrix.python-version, 't') }}
+        run: |
           twine check dist/*
+{% else %}
+          twine check dist/*
+{% endif %}
 {% for kind in ('macOS x86_64', 'macOS arm64') %}
       - name: Upload %(package_name)s wheel (%(kind)s)
         if: >
@@ -237,7 +244,7 @@ jobs:
 {% else %}
 {% if with_future_python %}
       - name: Install %(package_name)s ${{ matrix.python-version }}
-        if: matrix.python-version == '%(future_python_version)s'
+        if: startsWith(matrix.python-version, '%(future_python_version)s')
         run: |
           pip install -U wheel "setuptools %(setuptools_version_spec)s"
           # coverage might have a wheel on PyPI for a future python version which is
@@ -254,7 +261,7 @@ jobs:
 {% endif %}
       - name: Install %(package_name)s
 {% if with_future_python %}
-        if: matrix.python-version != '%(future_python_version)s'
+        if: ${{ !startsWith(matrix.python-version, '%(future_python_version)s') }}
 {% endif %}
         run: |
           pip install -U wheel "setuptools %(setuptools_version_spec)s"

--- a/src/zope/meta/c-code/tox.ini.j2
+++ b/src/zope/meta/c-code/tox.ini.j2
@@ -15,6 +15,9 @@ envlist =
 {% if with_free_threaded_python %}
     py%(newest_python_shortversion_t)s,py%(newest_python_shortversion_t)s-pure
 {% endif %}
+{% if with_free_threaded_python and with_future_python %}
+    py%(future_python_shortversion)st,py%(future_python_shortversion)st-pure
+{% endif %}
 {% if with_pypy %}
     pypy3
 {% endif %}

--- a/src/zope/meta/config_package.py
+++ b/src/zope/meta/config_package.py
@@ -421,7 +421,8 @@ class PackageConfiguration:
                 'manylinux.sh', self.path / '.manylinux.sh', self.config_type)
             (self.path / '.manylinux.sh').chmod(0o755)
             stop_at = None
-            if not self.with_future_python:
+            if not self.with_future_python \
+                    and not self.with_free_threaded_python:
                 stop_at = NEWEST_PYTHON_SHORTVERSION
             pkg_name_pattern = re.sub(r"[-_.]+", "?", self.path.name).lower()
             self.copy_with_meta(
@@ -432,7 +433,9 @@ class PackageConfiguration:
                 manylinux_install_setup=manylinux_install_setup,
                 manylinux_aarch64_tests=manylinux_aarch64_tests,
                 with_future_python=self.with_future_python,
+                with_free_threaded_python=self.with_free_threaded_python,
                 future_python_shortversion=FUTURE_PYTHON_SHORTVERSION,
+                newest_python_shortversion=NEWEST_PYTHON_SHORTVERSION,
                 supported_python_versions=supported_python_versions(
                     self.oldest_python, short_version=True),
                 stop_at=stop_at,


### PR DESCRIPTION
## Summary

Incorporates the changes from [zope.interface#375](https://github.com/zopefoundation/zope.interface/pull/375) into the meta templates so they apply to all c-code packages.

## Changes

- **`c-code/tests-strategy.j2`**: Expand free-threaded Python includes from Linux-only to all platforms (macOS, Windows); add future Python free-threaded entries (e.g. `3.15t`)
- **`c-code/manylinux-install.sh.j2`**: Add `cp*t` entries to `tox_env_map` (ordered before non-t for correct glob matching), PYBIN filter, and `--pre` pip condition
- **`c-code/tox.ini.j2`**: Add future Python free-threaded envlist entry (`py315t,py315t-pure`)
- **`config_package.py`**: Pass `with_free_threaded_python` and `newest_python_shortversion` to manylinux template; update `stop_at` logic
- **`CHANGES.rst`**: Document the changes

— _PR created by GitHub Copilot_