### PR TITLE
Remove duplicate Sphinx dependency.

### DIFF
--- a/src/zope/meta/default/tox-testenv.j2
+++ b/src/zope/meta/default/tox-testenv.j2
@@ -15,9 +15,6 @@ deps =
   {% for line in testenv_deps %}
     %(line)s
   {% endfor %}
-  {% if with_sphinx_doctests and with_future_python %}
-    Sphinx
-  {% endif %}
 {% if testenv_setenv %}
 setenv =
   {% for line in testenv_setenv %}

--- a/src/zope/meta/pure-python/tox.ini.j2
+++ b/src/zope/meta/pure-python/tox.ini.j2
@@ -13,9 +13,6 @@ deps =
 {% for line in testenv_deps %}
     %(line)s
 {% endfor %}
-{% if with_sphinx_doctests and with_future_python %}
-    Sphinx
-{% endif %}
 {% if coverage_setenv %}
 setenv =
 {% for line in coverage_setenv %}


### PR DESCRIPTION
This is a leftover from a time where we pinned Sphinx < 5 for future Python.
There is no need to add Sphinx only if future Python is enabled.

Used for https://github.com/zopefoundation/persistent/pull/236