### PR TITLE
Restrict readme-renderer for internal tests

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/src/zope/meta/pure-python
 [meta]
 template = "pure-python"
-commit-id = "92befcdf"
+commit-id = "966ac0d8"
 
 [python]
 with-windows = false
@@ -32,4 +32,9 @@ additional-rules = [
 [check-manifest]
 additional-ignores = [
     "docs/_build/html/_static/scripts/*",
+    ]
+
+[tox]
+testenv-deps = [
+    "readme-renderer < 45",
     ]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Change log
 2.2 (unreleased)
 ----------------
 
+- Restrict ``readme-renderer`` dependency to versions older than 45 for
+  the internal tests. This restriction can be removed when ``readme-renderer``
+  and its dependencies install cleanly under Python 3.15.
+
 - Expand free-threaded Python CI testing from Linux-only to all platforms
   (macOS, Windows) in ``c-code`` templates. Add future Python free-threaded
   variant (e.g. ``3.15t``) support to the test matrix, manylinux build

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ wheel_build_env = .pkg
 pip_pre = py315: true
 deps =
     setuptools >= 78.1.1,< 82
+    readme-renderer < 45
 commands =
     zope-testrunner --test-path=src {posargs:-vc}
 extras =
@@ -30,6 +31,7 @@ extras =
 basepython = python3
 deps =
     git+https://github.com/pypa/setuptools.git\#egg=setuptools
+    readme-renderer < 45
 
 [testenv:release-check]
 description = ensure that the distribution is ready to release
@@ -75,6 +77,7 @@ allowlist_externals =
     mkdir
 deps =
     coverage[toml]
+    readme-renderer < 45
 commands =
     mkdir -p {toxinidir}/parts/htmlcov
     coverage run -m zope.testrunner --test-path=src {posargs:-vc}


### PR DESCRIPTION
Alternative fix to #429 

Restrict ``readme-renderer`` dependency to versions older than 45 for the internal tests. This restriction can be removed when ``readme-renderer`` and its dependencies install cleanly under Python 3.15.