### PR TITLE
Add more pre-commit hooks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,4 +86,3 @@ jobs:
       with:
         name: meta.tar.gz
         path: dist/*gz
-

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/src/zope/meta/pure-python
 [meta]
 template = "pure-python"
-commit-id = "4f098ddc"
+commit-id = "fa846ff4"
 
 [python]
 with-windows = false
@@ -12,6 +12,11 @@ with-docs = true
 with-sphinx-doctests = false
 with-macos = false
 with-free-threaded-python = false
+
+[pre-commit]
+# The template fragments are included into other templates, their trailing
+# blank line separates them from the next fragment.
+whitespace-exclude = "^src/zope/meta/.*\\.j2$"
 
 [coverage]
 fail-under = 10

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,17 @@
 # https://github.com/zopefoundation/meta/tree/master/src/zope/meta/pure-python
 minimum_pre_commit_version: '3.6'
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+    - id: check-case-conflict
+    - id: check-merge-conflict
+    - id: check-toml
+    - id: check-yaml
+    - id: end-of-file-fixer
+      exclude: ^src/zope/meta/.*\.j2$
+    - id: trailing-whitespace
+      exclude: ^src/zope/meta/.*\.j2$
   - repo: https://github.com/pycqa/isort
     rev: "8.0.1"
     hooks:
@@ -27,3 +38,7 @@ repos:
     - id: flake8
       additional_dependencies:
         - flake8-debugger == 4.1.2
+  - repo: https://github.com/sphinx-contrib/sphinx-lint
+    rev: v1.0.2
+    hooks:
+    - id: sphinx-lint

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,20 @@ Change log
 2.2 (unreleased)
 ----------------
 
+- Add the ``check-case-conflict``, ``check-merge-conflict``, ``check-toml``,
+  ``check-yaml``, ``end-of-file-fixer`` and ``trailing-whitespace`` hooks from
+  ``pre-commit-hooks`` and the ``sphinx-lint`` hook to
+  ``.pre-commit-config.yaml``. Add ``whitespace-exclude`` and
+  ``sphinx-lint-exclude`` to the ``[pre-commit]`` section in ``.meta.toml`` to
+  hide files from them.
+  (`#284 <https://github.com/zopefoundation/meta/issues/284>`_)
+
+- Stop rendering a blank line at the end of ``tests.yml`` for packages which do
+  not use trusted publishing.
+
+- Fix the ``[pre-commit]`` example in the documentation: a backslash in a TOML
+  basic string has to be escaped, so ``"error\.py"`` is not valid TOML.
+
 - Configure ``zest.releaser`` to not add an extra message when using
   trusted publishing.
 

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@
 
 .. image:: https://coveralls.io/repos/github/zopefoundation/meta/badge.svg?branch=master
     :target: https://coveralls.io/github/zopefoundation/meta?branch=master
-        
+
 .. image:: https://readthedocs.org/projects/zopemeta/badge/?version=latest
     :target: https://zopemeta.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,4 +23,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/docs/narr.rst
+++ b/docs/narr.rst
@@ -382,8 +382,10 @@ updated. Example:
         ]
 
     [pre-commit]
-    teyit-exclude = "App/tests/fixtures/error\.py"
-    pyupgrade-exclude = "^src/zope/proxy/__init__\.py$"
+    teyit-exclude = "App/tests/fixtures/error\\.py"
+    pyupgrade-exclude = "^src/zope/proxy/__init__\\.py$"
+    whitespace-exclude = "^src/zope/i18n/locales/data/.*\\.xml$"
+    sphinx-lint-exclude = "^docs/articles/old-guide/.*\\.rst$"
 
 
     [readthedocs]
@@ -720,6 +722,21 @@ pyupgrade-exclude
   Regex for files to be hidden from pyupgrade. It might be a bit overly
   optimistic with its changes. This option has to be a string and is omitted
   when not defined.
+
+whitespace-exclude
+  Regex for files to be hidden from both ``trailing-whitespace`` and
+  ``end-of-file-fixer``. Use it for files whose exact bytes matter, such as
+  vendored data files, reference output compared by tests, and doctests whose
+  expected output contains trailing whitespace. This option has to be a string
+  and is omitted when not defined.
+
+sphinx-lint-exclude
+  Regex for files to be hidden from sphinx-lint. This option has to be a string
+  and is omitted when not defined.
+
+  A ``.rst`` file listed in ``whitespace-exclude`` usually has to be listed here
+  as well: sphinx-lint reports the very trailing whitespace that
+  ``trailing-whitespace`` is no longer allowed to remove.
 
 ReadTheDocs options
 ```````````````````

--- a/src/zope/meta/config_package.py
+++ b/src/zope/meta/config_package.py
@@ -383,6 +383,10 @@ class PackageConfiguration:
         teyit_exclude = self.meta_cfg["pre-commit"].get("teyit-exclude", "")
         pyupgrade_exclude = self.meta_cfg["pre-commit"].get(
             "pyupgrade-exclude", "")
+        whitespace_exclude = self.meta_cfg["pre-commit"].get(
+            "whitespace-exclude", "")
+        sphinx_lint_exclude = self.meta_cfg["pre-commit"].get(
+            "sphinx-lint-exclude", "")
 
         self.copy_with_meta(
             "pre-commit-config.yaml.j2",
@@ -391,6 +395,8 @@ class PackageConfiguration:
             oldest_python_version=self.oldest_python.replace(".", ""),
             teyit_exclude=teyit_exclude,
             pyupgrade_exclude=pyupgrade_exclude,
+            whitespace_exclude=whitespace_exclude,
+            sphinx_lint_exclude=sphinx_lint_exclude,
         )
 
     def readthedocs(self):

--- a/src/zope/meta/default/pre-commit-config.yaml.j2
+++ b/src/zope/meta/default/pre-commit-config.yaml.j2
@@ -1,5 +1,20 @@
 minimum_pre_commit_version: '3.6'
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+    - id: check-case-conflict
+    - id: check-merge-conflict
+    - id: check-toml
+    - id: check-yaml
+    - id: end-of-file-fixer
+{% if whitespace_exclude %}
+      exclude: %(whitespace_exclude)s
+{% endif %}
+    - id: trailing-whitespace
+{% if whitespace_exclude %}
+      exclude: %(whitespace_exclude)s
+{% endif %}
   - repo: https://github.com/pycqa/isort
     rev: "8.0.1"
     hooks:
@@ -31,3 +46,10 @@ repos:
     - id: flake8
       additional_dependencies:
         - flake8-debugger == 4.1.2
+  - repo: https://github.com/sphinx-contrib/sphinx-lint
+    rev: v1.0.2
+    hooks:
+    - id: sphinx-lint
+{% if sphinx_lint_exclude %}
+      exclude: %(sphinx_lint_exclude)s
+{% endif %}

--- a/src/zope/meta/default/tests.yml.j2
+++ b/src/zope/meta/default/tests.yml.j2
@@ -163,8 +163,8 @@ jobs:
       with:
         name: %(package_name)s.tar.gz
         path: dist/*gz
-
 {% if use_trusted_publishing %}
+
   publish:
     name: Publish to PyPI
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #284.

Issue #284 asks which of the hooks dropped in #282 — plus `docformatter` and `sphinx-lint` from the comment — are worth carrying for all ~200 repositories. Since this template is applied org-wide, I measured every candidate against 201 zope.meta-managed checkouts rather than judging them on reputation.

## Added

| Hook | Measured impact |
| --- | --- |
| `check-yaml` | 690 files, 0 currently failing, no multi-document YAML |
| `check-toml` | 402 files, 0 currently failing |
| `check-merge-conflict` | 0 current hits |
| `check-case-conflict` | 0 current hits |
| `trailing-whitespace` | 1045 text files in 121 repos. No `.py` among them — flake8 W291/W293 and autopep8 already cover Python; the value is in `.xml`, `.rst`, `.dtml`, `.zcml`, `.pt` |
| `end-of-file-fixer` | 604 text files in 196 repos, mostly `.txt`, `.rst`, `.pt`, `.toml` |
| `sphinx-lint` | 975 findings over 1508 `.rst`; 781 are trailing whitespace / missing final newline that the two fixers resolve, leaving 194 manual findings in 45 repos |

Fixers and validators run first so the existing linters see clean files, and `sphinx-lint` runs last so it does not report whitespace that `trailing-whitespace` has already removed.

## Not added, and why

- **`fix-encoding-pragma`** — removed from `pre-commit-hooks` in v6.0.0, which says to migrate to `pyupgrade`. `pyupgrade --py310-plus` is already configured and does this. One leftover pragma exists org-wide, in a deliberate non-ASCII test fixture.
- **`debug-statements`** — redundant with `flake8-debugger == 4.1.2`, already in the flake8 hook's `additional_dependencies`.
- **`rst-lint`** — the snippet in the issue is stale: current `restructuredtext-lint` rejects `--encoding`. It also emits 4606 errors, essentially all false positives on Sphinx directives (`doctest`, `automodule`, `autointerface`, `:mod:`, `:ref:`). Limiting it to root `README.rst`/`CHANGES.rst` is clean but adds little, since `twine check` in `tox -e release-check` already gatekeeps PyPI rendering.
- **`rstcheck`** — the issue hoped it could deal with Sphinx directives. It cannot here: 2272 errors even with the `[sphinx]` extra, because our docs use `autointerface` from `repoze.sphinx.autointerface`. `sphinx-lint` supersedes it.
- **`docformatter`** — a hard blocker. It strips the space in isort's `from x import \` continuation and isort puts it straight back; pre-commit judges each hook individually, so one of the two always reports "files were modified" and CI stays red forever. Independently it would rewrite 1970 files in 196 of 201 repos and crashes with a tokenize `ValueError` in 40 of them (docformatter 1.7.8).
- **`codespell`** — finds real typos but false-positives on Zope identifiers (`IInclude` → `include`, `fo`, `FileTests`) and deliberate spellings (`monkies`). Would need per-repo dictionaries; worth revisiting as opt-in.
- **`name-tests-test`** — 398 violations in 140 repos; `testFoo.py` is our convention.
- **`check-ast`** (redundant with flake8, 2 intentional bad-syntax fixtures), **`detect-private-key`** (3 legitimate ZEO test keys), **`check-added-large-files`** (3 vendored Zope assets over 500 kB) — all need excludes to buy very little in public repos with no secrets.
- **`actionlint`** — 0 findings; the workflows are generated and already clean.
- **`zizmor`** — worth doing, but not downstream. It reports ~44 findings per repo (36 `unpinned-uses`, 7 `excessive-permissions`, `artipacked`, `template-injection`), all originating in our own `tests.yml.j2` and therefore identical in all 200 repos. Shipping it here would turn every repository red for a defect that has to be fixed in one place. Better as its own issue against the templates.

## New `.meta.toml` options

`[pre-commit] whitespace-exclude` (applies to `trailing-whitespace` and `end-of-file-fixer` together) and `[pre-commit] sphinx-lint-exclude`, following the existing `teyit-exclude` / `pyupgrade-exclude` pattern. A `.rst` file listed in the first usually needs listing in the second too, otherwise sphinx-lint reports the whitespace the excluded fixer may no longer remove.

## Other changes

- `tests.yml.j2` no longer renders a blank line at EOF when trusted publishing is off. Without this, `end-of-file-fixer` and `config-package` would keep undoing each other in the four affected packages.
- This repository sets `whitespace-exclude = "^src/zope/meta/.*\\.j2$"`: the template fragments are `{% include %}`d into other templates, and their trailing blank line separates them from the next fragment.
- The `[pre-commit]` example in the documentation used `"error\.py"`, which is not valid TOML — a backslash in a basic string has to be escaped. Copying it would break a `.meta.toml`.

## Verification

- `pre-commit run --all-files` here: all 12 hooks pass, and a second consecutive run is a no-op — the check that catches a hook/generator ping-pong.
- Regenerated one checkout of each config type (`pure-python`, `c-code`, `zope-product`, `toolkit`, `buildout-recipe`) in a scratch copy: all five produce valid YAML with the same 12 hooks. `RestrictedPython` (trusted publishing on) shows no change around the publish block; `zopetoolkit` (off) loses exactly the trailing blank line.
- Ran the hooks against `DateTime`, which is doctest-heavy: converged after one pass, and its 53 tests still pass — the whitespace changes landed in prose, not in doctest expected output.

## Rollout notes

Re-running `config-package` org-wide will produce a whitespace-only diff in ~196 repos and new `sphinx-lint` failures in 45. The remaining sphinx-lint work is small per repo — `z3c.rml` (36), `groktoolkit` (26), `Zope` (15), `ZODB` (15), `persistent` (10), and 30 of the 45 need three or fewer fixes.

These repos need `whitespace-exclude` rather than fixes:

- `z3c.rml` — 176 `.pdf` and 30 `.rml` reference outputs compared byte-for-byte by its tests.
- `zope.i18n` — 282 vendored CLDR `.xml` data files.
- `zope.testrunner`, `ZODB`, `transaction` — doctest expected output whose trailing whitespace is significant (13 lines across the three).
