### PR TITLE
Fix silent pip upgrade failure on Windows in the c-code template

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Change log
 2.2 (unreleased)
 ----------------
 
+- Also set ``pip_pre`` for the free-threaded variant of a future Python
+  version in ``tox.ini``, as its dependencies are only available as
+  pre-releases just like those of the non-free-threaded variant.
+
 - Upgrade ``pip`` via ``python -m pip`` in the ``c-code`` test workflow
   template, as the ``pip.exe`` shim on Windows refuses to replace itself.
   Run all workflow steps under ``bash`` so that a failing command in a

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,13 @@ Change log
 2.2 (unreleased)
 ----------------
 
+- Upgrade ``pip`` via ``python -m pip`` in the ``c-code`` test workflow
+  template, as the ``pip.exe`` shim on Windows refuses to replace itself.
+  Run all workflow steps under ``bash`` so that a failing command in a
+  multi-command block is no longer swallowed on Windows, and collapse the
+  now-redundant OS-split pip cache steps.
+  (`#436 <https://github.com/zopefoundation/meta/issues/436>`_)
+
 - Configure ``zest.releaser`` to not add an extra message when using
   trusted publishing.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Change log
 2.2 (unreleased)
 ----------------
 
+- Rotate the pip cache key weekly in the ``c-code`` test workflow template.
+  ``actions/cache`` never replaces an existing key, so a corrupt cache entry
+  used to break every run restoring it until GitHub evicted the entry. A
+  rotating key abandons such an entry within a week instead.
+  (`#436 <https://github.com/zopefoundation/meta/issues/436>`_)
+
 - Also set ``pip_pre`` for the free-threaded variant of a future Python
   version in ``tox.ini``, as its dependencies are only available as
   pre-releases just like those of the non-free-threaded variant.

--- a/src/zope/meta/c-code/tests-cache.j2
+++ b/src/zope/meta/c-code/tests-cache.j2
@@ -13,29 +13,14 @@
       # to save the cache. So it must come before the thing we want to use
       # the cache.
       ###
-      - name: Get pip cache dir (default)
-        id: pip-cache-default
-        if: ${{ !startsWith(runner.os, 'Windows') }}
+      - name: Get pip cache dir
+        id: pip-cache
         run: |
           echo "dir=$(pip cache dir)" >>$GITHUB_OUTPUT
 
-      - name: Get pip cache dir (Windows)
-        id: pip-cache-windows
-        if: ${{ startsWith(runner.os, 'Windows') }}
-        run: |
-          echo "dir=$(pip cache dir)" >> $Env:GITHUB_OUTPUT
-
-      - name: pip cache (default)
+      - name: pip cache
         uses: actions/cache@v5
-        if: ${{ !startsWith(runner.os, 'Windows') }}
         with:
-          path: ${{ steps.pip-cache-default.outputs.dir }}
-          key: %(cache_key)s
-
-      - name: pip cache (Windows)
-        uses: actions/cache@v5
-        if: ${{ startsWith(runner.os, 'Windows') }}
-        with:
-          path: ${{ steps.pip-cache-windows.outputs.dir }}
+          path: ${{ steps.pip-cache.outputs.dir }}
           key: %(cache_key)s
 

--- a/src/zope/meta/c-code/tests-cache.j2
+++ b/src/zope/meta/c-code/tests-cache.j2
@@ -16,7 +16,7 @@
       - name: Get pip cache dir
         id: pip-cache
         run: |
-          echo "dir=$(pip cache dir)" >>$GITHUB_OUTPUT
+          echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
 
       - name: pip cache
         uses: actions/cache@v5

--- a/src/zope/meta/c-code/tests-cache.j2
+++ b/src/zope/meta/c-code/tests-cache.j2
@@ -13,6 +13,15 @@
       # to save the cache. So it must come before the thing we want to use
       # the cache.
       ###
+      - name: Get pip cache epoch
+        id: pip-cache-epoch
+        # ``actions/cache`` never replaces an entry: "if the provided key
+        # matches an existing cache, a new cache is not created". A corrupt
+        # entry would therefore break every run that restores it until GitHub
+        # evicts it. Rotating the key weekly abandons such an entry instead.
+        run: |
+          echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+
       - name: Get pip cache dir
         id: pip-cache
         run: |

--- a/src/zope/meta/c-code/tests.yml.j2
+++ b/src/zope/meta/c-code/tests.yml.j2
@@ -1,4 +1,4 @@
-{% set cache_key = "${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}" %}
+{% set cache_key = "${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}-${{ steps.pip-cache-epoch.outputs.week }}" %}
 ###
 # Initially copied from
 # https://github.com/actions/starter-workflows/blob/main/ci/python-package.yml
@@ -389,7 +389,7 @@ jobs:
             image: %(manylinux_aarch64)s
             python-version: "%(manylinux_python_version)s"
     steps:
-{% set cache_key = "${{ runner.os }}-pip_manylinux-${{ matrix.image }}-${{ matrix.python-version }}" %}
+{% set cache_key = "${{ runner.os }}-pip_manylinux-${{ matrix.image }}-${{ matrix.python-version }}-${{ steps.pip-cache-epoch.outputs.week }}" %}
 {% include 'tests-cache.j2' %}
 
       - name: Update pip

--- a/src/zope/meta/c-code/tests.yml.j2
+++ b/src/zope/meta/c-code/tests.yml.j2
@@ -45,6 +45,13 @@ on:
   # Allow to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+defaults:
+  run:
+    # ``pwsh`` propagates only the exit code of the *last* command of a
+    # multi-command block, so failures on Windows go unnoticed. ``bash``
+    # runs with ``-eo pipefail`` and aborts the step on the first failure.
+    shell: bash
+
 env:
   # Weirdly, this has to be a top-level key, not ``defaults.env``
   PYTHONHASHSEED: 8675309
@@ -92,7 +99,7 @@ jobs:
       - name: Install Build Dependencies (%(future_python_version)s)
         if: startsWith(matrix.python-version, '%(future_python_version)s')
         run: |
-          pip install -U pip
+          python -m pip install -U pip
           pip install -U "setuptools %(setuptools_version_spec)s" wheel twine cffi pycparser
 {% endif %}
       - name: Install Build Dependencies
@@ -100,7 +107,7 @@ jobs:
         if: ${{ !startsWith(matrix.python-version, '%(future_python_version)s') }}
 {% endif %}
         run: |
-          pip install -U pip
+          python -m pip install -U pip
           pip install -U "setuptools %(setuptools_version_spec)s" wheel twine
 
 {% for kind in ('macOS x86_64', 'macOS arm64', 'all other versions') %}
@@ -160,7 +167,7 @@ jobs:
 {% endif %}
         run: |
           # Install to collect dependencies into the (pip) cache.
-          pip install -U pip "setuptools %(setuptools_version_spec)s"
+          python -m pip install -U pip "setuptools %(setuptools_version_spec)s"
           pip install .[test]
 
       - name: Check %(package_name)s build
@@ -386,7 +393,7 @@ jobs:
 {% include 'tests-cache.j2' %}
 
       - name: Update pip
-        run: pip install -U pip
+        run: python -m pip install -U pip
 
       - name: Build %(package_name)s
         if: matrix.image != '%(manylinux_i686)s'
@@ -412,7 +419,7 @@ jobs:
           name: manylinux_${{ matrix.image }}_wheels.zip
 
       - name: Restore pip cache permissions
-        run: sudo chown -R $(whoami) ${{ steps.pip-cache-default.outputs.dir }}
+        run: sudo chown -R $(whoami) ${{ steps.pip-cache.outputs.dir }}
 {% if with_future_python %}
 
       - name: Prevent publishing wheels for unreleased Python versions

--- a/src/zope/meta/default/tox-testenv.j2
+++ b/src/zope/meta/default/tox-testenv.j2
@@ -8,7 +8,13 @@ package = wheel
 wheel_build_env = .pkg
 {% endif %}
 {% if with_future_python %}
+  {% if with_free_threaded_python %}
+pip_pre =
+    py%(future_python_shortversion)s: true
+    py%(future_python_shortversion)st: true
+  {% else %}
 pip_pre = py%(future_python_shortversion)s: true
+  {% endif %}
 {% endif %}
 deps =
     setuptools %(setuptools_version_spec)s


### PR DESCRIPTION
Fixes #436 (items 1 and 2).

`pip install -U pip` never upgraded pip on Windows — the `pip.exe` shim refuses to replace
itself — and pwsh only propagates the last command's exit code, so the failure was silent.
Hence `python -m pip` plus `defaults.run.shell: bash`.

With bash everywhere, `$Env:GITHUB_OUTPUT` is gone and the OS-split pip cache steps collapse
into one pair.

Verified by regenerating zope.interface: the only `tests.yml` changes are the ones above,
and `actionlint` is clean. Item 3 of #436 (the never-varying cache key) stays open.