### PR TITLE
Add `[coverage] combine` option

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/src/zope/meta/pure-python
 [meta]
 template = "pure-python"
-commit-id = "4f098ddc"
+commit-id = "c84e86d6"
 
 [python]
 with-windows = false
@@ -14,7 +14,7 @@ with-macos = false
 with-free-threaded-python = false
 
 [coverage]
-fail-under = 10
+fail-under = 18
 
 [coverage-run]
 source = "zope.meta"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Change log
 2.2 (unreleased)
 ----------------
 
+- Add ``[coverage] combine`` option to measure coverage across all supported
+  Python versions instead of a single one. It turns the ``coverage`` tox
+  environment into one which combines the data written by the test
+  environments, and makes the ``coverage`` job in ``tests.yml`` run them.
+
 - Configure ``zest.releaser`` to not add an extra message when using
   trusted publishing.
 

--- a/docs/narr.rst
+++ b/docs/narr.rst
@@ -242,6 +242,7 @@ updated. Example:
 
     [coverage]
     fail-under = 98
+    combine = true
 
     [coverage-run]
     additional-config = [
@@ -435,6 +436,33 @@ The corresponding section is named: ``[coverage]``.
 
 fail-under
   A minimal value of code coverage below which a test failure is issued.
+
+combine
+  Measure coverage across all supported Python versions instead of a single
+  one: true/false, default: false. Use it when no single version reaches
+  ``fail-under`` on its own. Switching it on
+
+  * lets each test environment write its own data file
+    (``COVERAGE_FILE=.coverage.{envname}``),
+  * turns ``[testenv:coverage]`` into an environment which only runs
+    ``coverage erase`` and ``coverage combine``, with a ``depends`` on all
+    environments contributing data,
+  * sets ``relative_files = true`` in ``[tool.coverage.run]``, so data files
+    written on different machines can be combined,
+  * and makes the ``coverage`` job in ``tests.yml`` run the test environments,
+    because each job gets its own machine and there would be nothing to
+    combine otherwise.
+
+  Anything the package configures itself — ``coverage-command``,
+  ``coverage-setenv``, ``testenv-setenv``, a ``depends`` line in
+  ``coverage-additional``, ``[github-actions] test-commands`` — keeps
+  precedence. Not supported for the ``c-code`` template, which has its own
+  ``tests.yml``.
+
+  Note that the tests then run twice in CI: once in their own job and once in
+  the ``coverage`` job. The ``fail-under`` check should be disabled in
+  ``testenv-commands`` so a single version failing to reach it does not fail
+  its own job.
 
 
 Coverage:run options

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ branch = true
 source = ["zope.meta"]
 
 [tool.coverage.report]
-fail_under = 10
+fail_under = 18
 precision = 2
 ignore_errors = true
 show_missing = true

--- a/src/zope/meta/config_package.py
+++ b/src/zope/meta/config_package.py
@@ -147,6 +147,58 @@ def prepend_space(text):
     return text
 
 
+def make_jinja_env(template_folders):
+    """Create the Jinja environment used to render the templates."""
+    return jinja2.Environment(
+        loader=jinja2.FileSystemLoader(template_folders),
+        variable_start_string='%(',
+        variable_end_string=')s',
+        keep_trailing_newline=True,
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+
+
+def combined_coverage_envs(supported_versions, additional_envlist=(),
+                           with_future_python=False,
+                           with_free_threaded_python=False,
+                           with_pypy=False):
+    """Names of the tox environments which contribute coverage data.
+
+    This is the `envlist` in `tox.ini` without the environments running no
+    tests, so it can be used as the `depends` of the `coverage` environment.
+    """
+    envs = [f'py{version}' for version in supported_versions]
+    if with_future_python:
+        envs.append(f'py{FUTURE_PYTHON_SHORTVERSION}')
+    if with_free_threaded_python:
+        envs.append(f'py{NEWEST_PYTHON_SHORTVERSION_T}')
+    if with_pypy:
+        envs.append('pypy3')
+    envs.extend(additional_envlist)
+    return envs
+
+
+def prepend_coverage_file(setenv, value):
+    """Prepend a `COVERAGE_FILE` entry to the tox option `setenv`.
+
+    A `COVERAGE_FILE` the package configured itself wins, so it keeps the
+    final say over where its coverage data is written.
+    """
+    if any(line.strip().startswith('COVERAGE_FILE') for line in setenv):
+        return list(setenv)
+    return [f'COVERAGE_FILE={value}', *setenv]
+
+
+def skip_env_regex(with_docs=True):
+    """Regex matching the tox environments which contribute no coverage data.
+    """
+    envs = ['lint', 'release-check']
+    if with_docs:
+        envs.append('docs')
+    return f'({"|".join(sorted(envs))})'
+
+
 class PackageConfiguration:
     add_manylinux = False
 
@@ -232,14 +284,7 @@ class PackageConfiguration:
 
     @cached_property
     def jinja_env(self):
-        return jinja2.Environment(
-            loader=jinja2.FileSystemLoader(self.template_folders),
-            variable_start_string='%(',
-            variable_end_string=')s',
-            keep_trailing_newline=True,
-            trim_blocks=True,
-            lstrip_blocks=True,
-        )
+        return make_jinja_env(self.template_folders)
 
     @cached_property
     def with_macos(self):
@@ -281,6 +326,10 @@ class PackageConfiguration:
     @cached_property
     def coverage_fail_under(self):
         return self.meta_cfg['coverage'].setdefault('fail-under', 0)
+
+    @cached_property
+    def coverage_combine(self):
+        return self.meta_cfg['coverage'].get('combine', False)
 
     @cached_property
     def branch_name(self):
@@ -485,6 +534,27 @@ class PackageConfiguration:
         testenv_deps = self.tox_option('testenv-deps')
         coverage_setenv = self.tox_option('coverage-setenv')
         lint_diff_on_failure = self.tox_option('lint-diff-on-failure', True)
+        if self.coverage_combine:
+            # Each test environment writes its own coverage data file, the
+            # `coverage` environment combines them instead of running the
+            # tests itself.
+            testenv_setenv = prepend_coverage_file(
+                testenv_setenv, '.coverage.{envname}')
+            coverage_setenv = prepend_coverage_file(
+                coverage_setenv, '.coverage')
+            if not coverage_command:
+                coverage_command = ['coverage erase', 'coverage combine']
+            if not any(line.startswith('depends')
+                       for line in coverage_additional):
+                depends = combined_coverage_envs(
+                    supported_python_versions(self.oldest_python,
+                                              short_version=True),
+                    additional_envlist,
+                    with_future_python=self.with_future_python,
+                    with_free_threaded_python=self.with_free_threaded_python,
+                    with_pypy=self.with_pypy)
+                coverage_additional = [
+                    f'depends = {",".join(depends)}', *coverage_additional]
         flake8_additional_sources = self.meta_cfg['flake8'].get(
             'additional-sources', '')
         if flake8_additional_sources:
@@ -561,7 +631,9 @@ class PackageConfiguration:
             gha_additional_install=gha_additional_install,
             gha_test_environment=gha_test_environment,
             gha_test_commands=gha_test_commands,
+            gha_skip_env_regex=skip_env_regex(self.with_docs),
             gha_services=gha_services,
+            coverage_combine=self.coverage_combine,
             gha_steps_before_checkout=gha_steps_before_checkout,
             with_docs=self.with_docs,
             with_sphinx_doctests=self.with_sphinx_doctests,
@@ -664,6 +736,10 @@ class PackageConfiguration:
 
         # Update coverage-related data
         coverage = toml_doc['tool']['coverage']
+        if self.coverage_combine:
+            # Combining data files written on different machines only works
+            # if the recorded file names are relative to the project root.
+            coverage['run']['relative_files'] = True
         add_cfg = self.meta_cfg['coverage-run'].get('additional-config', [])
         for key, value in parse_additional_config(add_cfg).items():
             coverage['run'][key] = value

--- a/src/zope/meta/default/tests.yml.j2
+++ b/src/zope/meta/default/tests.yml.j2
@@ -126,6 +126,12 @@ jobs:
       {% for line in gha_test_commands %}
         %(line)s
       {% endfor %}
+{% elif coverage_combine %}
+      # The `coverage` environment combines the data written by the test
+      # environments, so it has to run them: each job gets its own machine
+      # and there would be nothing to combine otherwise.
+      run: |
+        uvx --with tox-uv tox ${{ matrix.config[1] == 'coverage' && '--skip-env "%(gha_skip_env_regex)s"' || format('-e {0}', matrix.config[1]) }}
 {% else %}
       run: uvx --with tox-uv tox -e ${{ matrix.config[1] }}
 {% endif %}

--- a/src/zope/meta/tests/test_config_package.py
+++ b/src/zope/meta/tests/test_config_package.py
@@ -11,7 +11,92 @@
 #
 ##############################################################################
 
+import pathlib
 import unittest
+
+
+TEMPLATES = pathlib.Path(__file__).parent.parent
+
+
+def render(template_name, **context):
+    """Render one of the shipped templates the way `config-package` does."""
+    from zope.meta.config_package import make_jinja_env
+
+    env = make_jinja_env([TEMPLATES / context['config_type'],
+                          TEMPLATES / 'default'])
+    return env.get_template(template_name).render(**context)
+
+
+#: A `pure-python` package with docs, Sphinx doctests and a future Python,
+#: i. e. the values `PackageConfiguration.tox()` passes to `tox.ini.j2`.
+TOX_CONTEXT = {
+    'additional_envlist': [],
+    'build_requirements': ['setuptools >= 78.1.1,< 82'],
+    'config_type': 'pure-python',
+    'coverage_additional': [],
+    'coverage_basepython': 'python3',
+    'coverage_command': [],
+    'coverage_setenv': [],
+    'docs_deps': [],
+    'flake8_additional_sources': '',
+    'future_python_shortversion': '315',
+    'isort_additional_sources': '',
+    'lint_diff_on_failure': True,
+    'newest_python_shortversion_t': '314t',
+    'setuptools_version_spec': '>= 78.1.1,< 82',
+    'supported_python_versions': ['310', '311'],
+    'testenv_additional': [],
+    'testenv_additional_extras': [],
+    'testenv_commands': [],
+    'testenv_commands_pre': [],
+    'testenv_deps': [],
+    'testenv_setenv': [],
+    'testenv_skip_test_extra': False,
+    'with_docs': True,
+    'with_free_threaded_python': False,
+    'with_future_python': True,
+    'with_pypy': False,
+    'with_sphinx_doctests': True,
+}
+
+#: The same package as `TOX_CONTEXT`, for `tests.yml.j2`.
+TESTS_YML_CONTEXT = {
+    'config_type': 'pure-python',
+    'coverage_combine': False,
+    'future_python_shortversion': '315',
+    'future_python_version': '3.15',
+    'gha_additional_config': [],
+    'gha_additional_exclude': [],
+    'gha_additional_install': [],
+    'gha_services': [],
+    'gha_skip_env_regex': '(docs|lint|release-check)',
+    'gha_steps_before_checkout': [],
+    'gha_test_commands': [],
+    'gha_test_environment': [],
+    'newest_python_shortversion': '314',
+    'newest_python_shortversion_t': '314t',
+    'newest_python_version': '3.14',
+    'package_name': 'testpackage',
+    'pypy_version': '3.11',
+    'setuptools_version_spec': '>= 78.1.1,< 82',
+    'supported_python_versions': [('3.10', '310'), ('3.11', '311')],
+    'use_trusted_publishing': False,
+    'with_docs': True,
+    'with_free_threaded_python': False,
+    'with_future_python': True,
+    'with_macos': False,
+    'with_pypy': False,
+    'with_sphinx_doctests': True,
+    'with_windows': False,
+}
+
+DEFAULT_TEST_COMMAND = (
+    '      run: uvx --with tox-uv tox -e ${{ matrix.config[1] }}\n')
+COMBINE_TEST_COMMAND = """\
+        uvx --with tox-uv tox ${{ matrix.config[1] == 'coverage' \
+&& '--skip-env "(docs|lint|release-check)"' \
+|| format('-e {0}', matrix.config[1]) }}
+"""
 
 
 class ConfigPackageTests(unittest.TestCase):
@@ -22,3 +107,103 @@ class ConfigPackageTests(unittest.TestCase):
         self.assertIsNone(prepend_space(None))
         self.assertEqual('', prepend_space(''))
         self.assertEqual(' foobar', prepend_space('foobar'))
+
+
+class CombinedCoverageTests(unittest.TestCase):
+    """Tests for the ``[coverage] combine`` option."""
+
+    def test_combined_coverage_envs(self):
+        from zope.meta.config_package import combined_coverage_envs
+
+        self.assertEqual(['py310', 'py311'],
+                         combined_coverage_envs(['310', '311']))
+
+    def test_combined_coverage_envs__all_variants(self):
+        from zope.meta.config_package import FUTURE_PYTHON_SHORTVERSION
+        from zope.meta.config_package import NEWEST_PYTHON_SHORTVERSION_T
+        from zope.meta.config_package import combined_coverage_envs
+
+        self.assertEqual(
+            ['py310',
+             f'py{FUTURE_PYTHON_SHORTVERSION}',
+             f'py{NEWEST_PYTHON_SHORTVERSION_T}',
+             'pypy3',
+             'py311-datetime'],
+            combined_coverage_envs(
+                ['310'],
+                ['py311-datetime'],
+                with_future_python=True,
+                with_free_threaded_python=True,
+                with_pypy=True))
+
+    def test_prepend_coverage_file(self):
+        from zope.meta.config_package import prepend_coverage_file
+
+        self.assertEqual(['COVERAGE_FILE=.coverage'],
+                         prepend_coverage_file([], '.coverage'))
+        self.assertEqual(['COVERAGE_FILE=.coverage', 'FOO=bar'],
+                         prepend_coverage_file(['FOO=bar'], '.coverage'))
+
+    def test_prepend_coverage_file__keeps_configured_value(self):
+        from zope.meta.config_package import prepend_coverage_file
+
+        self.assertEqual(
+            ['COVERAGE_FILE=elsewhere'],
+            prepend_coverage_file(['COVERAGE_FILE=elsewhere'], '.coverage'))
+
+    def test_skip_env_regex(self):
+        from zope.meta.config_package import skip_env_regex
+
+        self.assertEqual('(docs|lint|release-check)', skip_env_regex())
+        self.assertEqual('(lint|release-check)', skip_env_regex(False))
+
+    def test_tox_ini__coverage_env_combines(self):
+        tox_ini = render('tox.ini.j2', **dict(
+            TOX_CONTEXT,
+            coverage_additional=['depends = py310,py311'],
+            coverage_command=['coverage erase', 'coverage combine'],
+            coverage_setenv=['COVERAGE_FILE=.coverage'],
+            testenv_setenv=['COVERAGE_FILE=.coverage.{envname}'],
+        ))
+        testenv, coverage_env = tox_ini.split('[testenv:coverage]')
+
+        self.assertIn('setenv =\n    COVERAGE_FILE=.coverage.{envname}\n',
+                      testenv)
+        self.assertIn('setenv =\n    COVERAGE_FILE=.coverage\n', coverage_env)
+        self.assertIn('    coverage erase\n    coverage combine\n',
+                      coverage_env)
+        self.assertIn('\ndepends = py310,py311\n', coverage_env)
+
+    def test_tox_ini__coverage_env_measures_by_default(self):
+        tox_ini = render('tox.ini.j2', **TOX_CONTEXT)
+        coverage_env = tox_ini.split('[testenv:coverage]')[1]
+
+        self.assertIn(
+            '    coverage run -m zope.testrunner --test-path=src'
+            ' {posargs:-vc}\n',
+            coverage_env)
+        self.assertNotIn('coverage combine', coverage_env)
+        self.assertNotIn('depends', coverage_env)
+
+    def test_tests_yml__coverage_job_runs_the_test_envs(self):
+        tests_yml = render('tests.yml.j2',
+                           **dict(TESTS_YML_CONTEXT, coverage_combine=True))
+
+        self.assertIn(COMBINE_TEST_COMMAND, tests_yml)
+        self.assertNotIn(DEFAULT_TEST_COMMAND, tests_yml)
+
+    def test_tests_yml__test_command_unchanged_by_default(self):
+        tests_yml = render('tests.yml.j2', **TESTS_YML_CONTEXT)
+
+        self.assertIn(DEFAULT_TEST_COMMAND, tests_yml)
+        self.assertNotIn('--skip-env', tests_yml)
+
+    def test_tests_yml__explicit_test_commands_win(self):
+        tests_yml = render('tests.yml.j2', **dict(
+            TESTS_YML_CONTEXT,
+            coverage_combine=True,
+            gha_test_commands=['make test'],
+        ))
+
+        self.assertIn('      run: |\n        make test\n', tests_yml)
+        self.assertNotIn('--skip-env', tests_yml)

--- a/src/zope/meta/tests/test_config_package.py
+++ b/src/zope/meta/tests/test_config_package.py
@@ -14,14 +14,20 @@
 import pathlib
 import unittest
 
+from zope.meta.config_package import FUTURE_PYTHON_SHORTVERSION
+from zope.meta.config_package import NEWEST_PYTHON_SHORTVERSION_T
+from zope.meta.config_package import combined_coverage_envs
+from zope.meta.config_package import make_jinja_env
+from zope.meta.config_package import prepend_coverage_file
+from zope.meta.config_package import prepend_space
+from zope.meta.config_package import skip_env_regex
+
 
 TEMPLATES = pathlib.Path(__file__).parent.parent
 
 
 def render(template_name, **context):
     """Render one of the shipped templates the way `config-package` does."""
-    from zope.meta.config_package import make_jinja_env
-
     env = make_jinja_env([TEMPLATES / context['config_type'],
                           TEMPLATES / 'default'])
     return env.get_template(template_name).render(**context)
@@ -101,8 +107,8 @@ COMBINE_TEST_COMMAND = """\
 
 class ConfigPackageTests(unittest.TestCase):
 
-    def test_prepend_space(self):
-        from zope.meta.config_package import prepend_space
+    def test_config_package__prepend_space__1(self):
+        """It prepends a space to a non-empty text."""
 
         self.assertIsNone(prepend_space(None))
         self.assertEqual('', prepend_space(''))
@@ -112,16 +118,14 @@ class ConfigPackageTests(unittest.TestCase):
 class CombinedCoverageTests(unittest.TestCase):
     """Tests for the ``[coverage] combine`` option."""
 
-    def test_combined_coverage_envs(self):
-        from zope.meta.config_package import combined_coverage_envs
+    def test_config_package__combined_coverage_envs__1(self):
+        """It returns one environment per supported Python version."""
 
         self.assertEqual(['py310', 'py311'],
                          combined_coverage_envs(['310', '311']))
 
-    def test_combined_coverage_envs__all_variants(self):
-        from zope.meta.config_package import FUTURE_PYTHON_SHORTVERSION
-        from zope.meta.config_package import NEWEST_PYTHON_SHORTVERSION_T
-        from zope.meta.config_package import combined_coverage_envs
+    def test_config_package__combined_coverage_envs__2(self):
+        """It appends future, free-threaded, PyPy and additional envs."""
 
         self.assertEqual(
             ['py310',
@@ -136,28 +140,30 @@ class CombinedCoverageTests(unittest.TestCase):
                 with_free_threaded_python=True,
                 with_pypy=True))
 
-    def test_prepend_coverage_file(self):
-        from zope.meta.config_package import prepend_coverage_file
+    def test_config_package__prepend_coverage_file__1(self):
+        """It prepends the ``COVERAGE_FILE`` entry."""
 
         self.assertEqual(['COVERAGE_FILE=.coverage'],
                          prepend_coverage_file([], '.coverage'))
         self.assertEqual(['COVERAGE_FILE=.coverage', 'FOO=bar'],
                          prepend_coverage_file(['FOO=bar'], '.coverage'))
 
-    def test_prepend_coverage_file__keeps_configured_value(self):
-        from zope.meta.config_package import prepend_coverage_file
+    def test_config_package__prepend_coverage_file__2(self):
+        """It keeps a ``COVERAGE_FILE`` the package configured itself."""
 
         self.assertEqual(
             ['COVERAGE_FILE=elsewhere'],
             prepend_coverage_file(['COVERAGE_FILE=elsewhere'], '.coverage'))
 
-    def test_skip_env_regex(self):
-        from zope.meta.config_package import skip_env_regex
+    def test_config_package__skip_env_regex__1(self):
+        """It matches the environments contributing no coverage data."""
 
         self.assertEqual('(docs|lint|release-check)', skip_env_regex())
         self.assertEqual('(lint|release-check)', skip_env_regex(False))
 
-    def test_tox_ini__coverage_env_combines(self):
+    def test_config_package__tox_ini__1(self):
+        """It renders a coverage environment combining the data files."""
+
         tox_ini = render('tox.ini.j2', **dict(
             TOX_CONTEXT,
             coverage_additional=['depends = py310,py311'],
@@ -174,7 +180,9 @@ class CombinedCoverageTests(unittest.TestCase):
                       coverage_env)
         self.assertIn('\ndepends = py310,py311\n', coverage_env)
 
-    def test_tox_ini__coverage_env_measures_by_default(self):
+    def test_config_package__tox_ini__2(self):
+        """It renders a coverage environment measuring by default."""
+
         tox_ini = render('tox.ini.j2', **TOX_CONTEXT)
         coverage_env = tox_ini.split('[testenv:coverage]')[1]
 
@@ -185,20 +193,26 @@ class CombinedCoverageTests(unittest.TestCase):
         self.assertNotIn('coverage combine', coverage_env)
         self.assertNotIn('depends', coverage_env)
 
-    def test_tests_yml__coverage_job_runs_the_test_envs(self):
+    def test_config_package__tests_yml__1(self):
+        """It runs the test environments in the coverage job."""
+
         tests_yml = render('tests.yml.j2',
                            **dict(TESTS_YML_CONTEXT, coverage_combine=True))
 
         self.assertIn(COMBINE_TEST_COMMAND, tests_yml)
         self.assertNotIn(DEFAULT_TEST_COMMAND, tests_yml)
 
-    def test_tests_yml__test_command_unchanged_by_default(self):
+    def test_config_package__tests_yml__2(self):
+        """It leaves the test command unchanged if combining is off."""
+
         tests_yml = render('tests.yml.j2', **TESTS_YML_CONTEXT)
 
         self.assertIn(DEFAULT_TEST_COMMAND, tests_yml)
         self.assertNotIn('--skip-env', tests_yml)
 
-    def test_tests_yml__explicit_test_commands_win(self):
+    def test_config_package__tests_yml__3(self):
+        """It prefers the test commands configured by the package."""
+
         tests_yml = render('tests.yml.j2', **dict(
             TESTS_YML_CONTEXT,
             coverage_combine=True,


### PR DESCRIPTION
Measure coverage across all supported Python versions instead of a single one.

Doing this today costs a package a hand-written GitHub Actions expression, a `depends = py310,…` list maintained by hand, and raw `relative_files` config. `[coverage] combine = true` wires up all of it; anything the package configures itself still wins. Defaults are unchanged — regenerating an untouched `pure-python` package produces a byte-identical result.

Not supported for `c-code`, which has its own `tests.yml`.

— _Comment created by Claude_

These are the changes needed for https://github.com/zopefoundation/RestrictedPython/pull/238