### PR TITLE
Fix disappearing top comment in ``pyproject.toml`` with newer ``tomlkit``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Change log
 2.2 (unreleased)
 ----------------
 
+- Fix disappearing top comment in ``pyproject.toml`` with newer ``tomlkit``.
+  (`#440 <https://github.com/zopefoundation/meta/issues/440>`_)
+
 - Add ``[coverage] combine`` option to measure coverage across all supported
   Python versions instead of a single one. It turns the ``coverage`` tox
   environment into one which combines the data written by the test

--- a/src/zope/meta/config_package.py
+++ b/src/zope/meta/config_package.py
@@ -690,9 +690,7 @@ class PackageConfiguration:
     def pyproject_toml(self):
         """Modify pyproject.toml with meta options."""
         toml_path = self.path / 'pyproject.toml'
-        toml_doc = get_pyproject_toml(
-            toml_path,
-            comment=META_HINT.format(config_type=self.config_type))
+        toml_doc = get_pyproject_toml(toml_path)
 
         # Capture some pre-transformation data
         old_requires = toml_doc.get('build-system', {}).get('requires', [])
@@ -776,8 +774,13 @@ class PackageConfiguration:
         if toml_doc['tool']['coverage'].get('paths'):
             toml_doc['tool']['coverage']['paths']['source'].multiline(True)
 
+        preamble = META_HINT.format(config_type=self.config_type)
+        toml_contents = tomlkit.dumps(toml_doc, sort_keys=True)
+        if not toml_contents.startswith(preamble):
+            toml_contents = f'{preamble}\n{toml_contents}'
+
         with open(toml_path, 'w') as fp:
-            tomlkit.dump(toml_doc, fp, sort_keys=True)
+            fp.write(toml_contents)
 
     def render_with_meta(self, template_name, config_type, **kw):
         """Read and render a Jinja template source file"""

--- a/src/zope/meta/shared/packages.py
+++ b/src/zope/meta/shared/packages.py
@@ -47,14 +47,11 @@ https://github.com/zopefoundation/meta/tree/master/src/zope/meta/{config_type}
 -->"""
 
 
-def get_pyproject_toml(path: pathlib.Path, comment='') -> TOMLDocument:
+def get_pyproject_toml(path: pathlib.Path) -> TOMLDocument:
     """Parse ``pyproject.toml`` and return its values as ``TOMLDocument``.
 
     Args:
         path (str, pathlib.Path): Filesystem path to a pyproject.toml file.
-
-    Kwargs:
-        comment (str): Optional comment added to the top of the file.
 
     Returns:
         A TOMLDocument instance from the pyproject.toml file.
@@ -64,11 +61,6 @@ def get_pyproject_toml(path: pathlib.Path, comment='') -> TOMLDocument:
             toml_contents = fp.read()
     else:
         toml_contents = ''
-
-    if comment and not\
-       (toml_contents.startswith(comment) or
-            toml_contents.startswith(f'# \n{comment}')):
-        toml_contents = f'{comment}\n{toml_contents}'
 
     return tomlkit.loads(toml_contents)
 


### PR DESCRIPTION
Fixes #440 

Manually tested with ``tomlkit`` latest release (0.15.1) and the previously working release 0.14.0.

This code will cause duplicate comments under these circumstances:
- the sandbox has ``tomlkit`` 0.14.0 or earlier AND
- the package to be configured has the older-style comment at the top of ``pyproject.toml``
