### PR TITLE
Use pinned commit hash for GH Action pypa/gh-action-pypi-publish

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Change log
 2.2 (unreleased)
 ----------------
 
+- Use pinned commit hash for GH Action pypa/gh-action-pypi-publish.
+  (`#441 <https://github.com/zopefoundation/meta/issues/441>`_)
+
 - Add ``[coverage] combine`` option to measure coverage across all supported
   Python versions instead of a single one. It turns the ``coverage`` tox
   environment into one which combines the data written by the test

--- a/src/zope/meta/c-code/tests.yml.j2
+++ b/src/zope/meta/c-code/tests.yml.j2
@@ -466,7 +466,7 @@ jobs:
           find dist/ -name "*linux_x86_64*" -type f -delete || true
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           skip-existing: true
           packages-dir: dist/

--- a/src/zope/meta/default/tests.yml.j2
+++ b/src/zope/meta/default/tests.yml.j2
@@ -198,7 +198,7 @@ jobs:
           ls -lR dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           skip-existing: true
           packages-dir: dist/


### PR DESCRIPTION
Fixes #441 

Manually tested with RestrictedPython: Commit https://github.com/zopefoundation/RestrictedPython/commit/a4e71358dc5a6dddba8055613560025c0e157ba7 makes the warning go away on https://github.com/zopefoundation/RestrictedPython/security/code-scanning

The actions code has a low package release frequency, so this shouldn't add too much work.