### PR TITLE
Offer to create a pull request at the end of a `config-package` run

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Change log
 2.2 (unreleased)
 ----------------
 
+- Offer to create a pull request via ``gh`` at the end of a ``config-package``
+  run, like ``update-python-support`` already does.
+
 - Use pinned commit hash for GH Action pypa/gh-action-pypi-publish.
   (`#441 <https://github.com/zopefoundation/meta/issues/441>`_)
   

--- a/docs/narr.rst
+++ b/docs/narr.rst
@@ -125,7 +125,9 @@ The script does the following steps:
    ``$PATH`` or in the ``bin`` subfolder of the current working directory.
 #. Create a branch and a pull request. (Prevent an automatic commit of all
    changes with the command line switch ``--no-commit``, or an automatic push
-   to GitHub using the command line switch ``--no-push``.)
+   to GitHub using the command line switch ``--no-push``.) Creating the pull
+   request requires being logged in via ``gh auth login``, the script asks
+   before doing so.
 
 After running the script you should manually do the following steps:
 

--- a/src/zope/meta/config_package.py
+++ b/src/zope/meta/config_package.py
@@ -25,6 +25,7 @@ from packaging.version import parse as parse_version
 from .set_branch_protection_rules import set_branch_protection
 from .shared.call import abort
 from .shared.call import call
+from .shared.git import create_pull_request
 from .shared.git import get_branch_name
 from .shared.git import get_commit_id
 from .shared.git import git_branch
@@ -334,6 +335,10 @@ class PackageConfiguration:
     @cached_property
     def branch_name(self):
         return get_branch_name(self.args.branch_name, self.config_type)
+
+    @cached_property
+    def commit_message(self):
+        return self.args.commit_msg or f'Configuring for {self.config_type}'
 
     def _add_project_to_config_type_list(self):
         """Add the current project to packages.txt if it is not there"""
@@ -901,16 +906,14 @@ class PackageConfiguration:
             ]
             if self.config_type != 'toolkit':
                 to_add.append('MANIFEST.in')
+            pushed = False
             if self.args.commit:
                 call('git', 'add', *to_add)
-                if self.args.commit_msg:
-                    commit_msg = self.args.commit_msg
-                else:
-                    commit_msg = f'Configuring for {self.config_type}'
-                call('git', 'commit', '-m', commit_msg)
+                call('git', 'commit', '-m', self.commit_message)
                 if self.args.push:
                     call('git', 'push', '--set-upstream',
                          'origin', self.branch_name)
+                    pushed = True
             print()
             print('If you are an admin and are logged in via `gh auth login`')
             print('update branch protection rules? (y/N)?', end=' ')
@@ -926,10 +929,12 @@ class PackageConfiguration:
                 else:
                     abort(-1)
             print()
-            print('If everything went fine up to here:')
             if updating:
                 print('Updated the previously created PR.')
+            elif pushed:
+                create_pull_request(self.commit_message)
             else:
+                print('If everything went fine up to here:')
                 print('Create a PR, using the URL shown above.')
 
 

--- a/src/zope/meta/pep_420.py
+++ b/src/zope/meta/pep_420.py
@@ -15,6 +15,7 @@ import pathlib
 import shutil
 
 from .shared.call import call
+from .shared.git import create_pull_request
 from .shared.git import git_branch
 from .shared.path import change_dir
 from .shared.script_args import get_shared_parser
@@ -100,15 +101,7 @@ def main():
                 if updating:
                     print("Updated the previously created PR.")
                 else:
-                    print(
-                        "Are you logged in via `gh auth login` to create a PR?"
-                        " (y/N)?", end=" ",
-                    )
-                    if input().lower() == "y":
-                        call("gh", "pr", "create", "--fill", "--title", msg)
-                    else:
-                        print("If everything went fine up to here:")
-                        print("Create a PR, using the URL shown above.")
+                    create_pull_request(msg)
             print("Applied all changes. Please push manually.")
         else:
             print("Applied all changes. Please check and commit manually.")

--- a/src/zope/meta/shared/git.py
+++ b/src/zope/meta/shared/git.py
@@ -49,3 +49,18 @@ def git_branch(branch_name) -> bool:
         call('git', 'checkout', '-b', branch_name)
         updating = False
     return updating
+
+
+def create_pull_request(title):
+    """Offer to create a pull request for the current branch.
+
+    Requires the user to be logged in via `gh auth login`.
+    """
+    print(
+        'Are you logged in via `gh auth login` to'
+        ' create a PR? (y/N)?', end=' ')
+    if input().lower() == 'y':
+        call('gh', 'pr', 'create', '--fill', '--title', title)
+    else:
+        print('If everything went fine up to here:')
+        print('Create a PR, using the URL shown above.')

--- a/src/zope/meta/update_python_support.py
+++ b/src/zope/meta/update_python_support.py
@@ -22,6 +22,7 @@ import tomlkit
 
 from .shared.call import call
 from .shared.call import wait_for_accept
+from .shared.git import create_pull_request
 from .shared.git import get_branch_name
 from .shared.git import git_branch
 from .shared.packages import FUTURE_PYTHON_VERSION
@@ -206,14 +207,6 @@ def main():
                 if updating:
                     print('Updated the previously created PR.')
                 else:
-                    print(
-                        'Are you logged in via `gh auth login` to'
-                        ' create a PR? (y/N)?', end=' ')
-                    if input().lower() == 'y':
-                        call('gh', 'pr', 'create', '--fill', '--title',
-                             'Update Python version support.')
-                    else:
-                        print('If everything went fine up to here:')
-                        print('Create a PR, using the URL shown above.')
+                    create_pull_request('Update Python version support.')
             else:
                 print('Applied all changes. Please check and commit manually.')


### PR DESCRIPTION
`config-package` now asks whether to create the PR via `gh`, just like `update-python-support` does. The prompt is extracted into `shared.git.create_pull_request()` and reused by `update-python-support` and `pep-420`.

Only offered when the run actually pushed a newly created branch; the previous messages are kept for the "branch already existed" and `--no-push` cases.